### PR TITLE
Bump dependancies on base and deepseq

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -35,8 +35,8 @@ library
     Data.HashSet
 
   build-depends:
-    base >= 4 && < 4.5,
-    deepseq >= 1.1 && < 1.3,
+    base >= 4 && < 4.6,
+    deepseq >= 1.1 && < 1.4,
     hashable >= 1.0.1.1 && < 1.2
 
   other-modules:


### PR DESCRIPTION
This is needed to fix compilation with the latest GHC 7.4.0.20111215
snapshot build.
