### PR TITLE
Add function insertLookupWithKey

### DIFF
--- a/Data/FullList/Lazy.hs
+++ b/Data/FullList/Lazy.hs
@@ -27,6 +27,7 @@ module Data.FullList.Lazy
     , insert
     , delete
     , insertWith
+    , insertLookupWith
     , adjust
 
       -- * Combine
@@ -206,6 +207,25 @@ insertWithL = go
         | otherwise = Cons k' v' (go f k v xs)
 #if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE insertWithL #-}
+#endif
+
+insertLookupWith :: Eq k => (v -> v -> v) -> k -> v -> FullList k v -> (Maybe v, FullList k v)
+insertLookupWith f !k v (FL k' v' xs)
+    | k == k'   = (Just v', FL k (f v v') xs)
+    | otherwise = let (found, l) = insertLookupWithL f k v xs in (found, FL k' v' l)
+#if __GLASGOW_HASKELL__ >= 700
+{-# INLINABLE insertLookupWith #-}
+#endif
+
+insertLookupWithL :: Eq k => (v -> v -> v) -> k -> v -> List k v -> (Maybe v, List k v)
+insertLookupWithL = go
+  where
+    go _ !k v Nil = (Nothing, Cons k v Nil)
+    go f k v (Cons k' v' xs)
+        | k == k'   = (Just v', Cons k (f v v') xs)
+        | otherwise = let (found, l) = go f k v xs in (found, Cons k' v' l)
+#if __GLASGOW_HASKELL__ >= 700
+{-# INLINABLE insertLookupWithL #-}
 #endif
 
 adjust :: Eq k => (v -> v) -> k -> FullList k v -> FullList k v

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -219,9 +219,10 @@ insertLookupWithKey f k0 v0 t0 = go h0 k0 v0 t0
         | zero h sm    = let (found, l') = go h k v l in (found, Bin sm l' r)
         | otherwise    = let (found, r') = go h k v r in (found, Bin sm l  r')
     go h k v t@(Tip h' l)
-        | h == h'       = (Just v, Tip h $ FL.insertWith (f k) k v l)
+        | h == h'       = let (found, fl) = FL.insertLookupWith (f k) k v l
+                          in (found, Tip h fl)
         | otherwise     = (Nothing, join h (Tip h $ FL.singleton k v) h' t)
-    go h k v Nil        = (Nothing, Tip h $ FL.singleton k v)
+    go h k v Empty      = (Nothing, Tip h $ FL.singleton k v)
 #if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE insertLookupWithKey #-}
 #endif

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -160,9 +160,10 @@ insertLookupWithKey f k0 !v0 t0 = go h0 k0 v0 t0
         | zero h sm    = let (found, l') = go h k v l in (found, Bin sm l' r)
         | otherwise    = let (found, r') = go h k v r in (found, Bin sm l  r')
     go h k v t@(Tip h' l)
-        | h == h'       = (Just v, Tip h $ FL.insertWith (f k) k v l)
+        | h == h'       = let (found, fl) = FL.insertLookupWith (f k) k v l
+                          in (found, Tip h fl)
         | otherwise     = (Nothing, join h (Tip h $ FL.singleton k v) h' t)
-    go h k v Nil        = (Nothing, Tip h $ FL.singleton k v)
+    go h k v Empty      = (Nothing, Tip h $ FL.singleton k v)
 #if __GLASGOW_HASKELL__ >= 700
 {-# INLINABLE insertLookupWithKey #-}
 #endif


### PR DESCRIPTION
Hi Johan,

Would you consider adding `insertLookupWithKey` to `unordered-containers`?

This function is similar to the equivalently named function in `Data.Map` and `Data.IntMap`.

O(min(n,W)). The expression (`insertLookupWithKey' f k x map`) is a pair where the first element is equal to (`lookup k map`) and the second element equal to (`insertWith' (f k) k x map`).

``` haskell
insertLookupWithKey :: (Eq k, Hashable k)
                    => (k -> v -> v -> v) -> k -> v -> HashMap k v
                    -> (Maybe v, HashMap k v)
```
