### PR TITLE
change pattern match order in unionArrayBy

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -627,7 +627,7 @@ unionArrayBy f b1 b2 ary1 ary2 = A.run $ do
             | otherwise     = do
                 A.write mary i =<< A.index_ ary2 i2
                 go (i+1) (i1  ) (i2+1) (m `unsafeShiftL` 1)
-    go 0 0 0 1
+    go 0 0 0 (b' .&. negate b') -- XXX: b' must be non-zero
     return mary
     -- TODO: For the case where b1 .&. b2 == b1, i.e. when one is a
     -- subset of the other, we could use a slightly simpler algorithm,


### PR DESCRIPTION
- Benchmark (before, after first commit, after second commit)

```
mean: 318.8765 us, lb 316.7192 us, ub 321.4764 us, ci 0.950
std dev: 12.15109 us, lb 9.980074 us, ub 15.77856 us, ci 0.950
```

```
mean: 283.3417 us, lb 281.6590 us, ub 285.5163 us, ci 0.950
std dev: 9.735885 us, lb 7.903786 us, ub 12.89564 us, ci 0.950
```

```
mean: 259.8358 us, lb 258.3919 us, ub 261.5228 us, ci 0.950
std dev: 8.022606 us, lb 6.724754 us, ub 9.935344 us, ci 0.950
```
