### PR TITLE
Don't leave a BitmapIndexed with only one child (issue #39).

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -479,7 +479,15 @@ delete k0 m0 = go h0 k0 0 m0
                 then t
                 else case st' of
                 Empty | A.length ary == 1 -> Empty
-                      | otherwise -> BitmapIndexed (b .&. complement m) (A.delete ary i)
+                      | A.length ary == 2 ->
+                          case (i, A.index ary 0, A.index ary 1) of
+                          (0, _, l@(Leaf _ _)) -> l
+                          (1, l@(Leaf _ _), _) -> l
+                          _                    -> bIndexed
+                      | otherwise -> bIndexed
+                    where
+                      bIndexed = BitmapIndexed (b .&. complement m) (A.delete ary i)
+                l@(Leaf _ _) | A.length ary == 1 -> l
                 _ -> BitmapIndexed b (A.update ary i st')
       where m = mask h s
             i = sparseIndex b m
@@ -826,6 +834,11 @@ filterWithKey pred = go
         step !ary !mary !b i !j !bi n
             | i >= n = case j of
                 0 -> return Empty
+                1 -> do
+                    ch <- A.read mary 0
+                    case ch of
+                      l@(Leaf _ _) -> return l
+                      _            -> BitmapIndexed b <$> trim mary 1
                 _ -> do
                     ary2 <- trim mary j
                     return $! if j == maxChildren


### PR DESCRIPTION
In some cases `filter` and `delete` would leave a BitmapIndexed with only one child.  But when the map was rebuild using `fromList . toList` then the internal representation of the tree was obviously slightly different.  This   broke equality since it assumes that equal maps are also structurally equal.
