### PR TITLE
Generic Instances for HashMap and HashSet

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -1,5 +1,9 @@
 {-# LANGUAGE BangPatterns, CPP, DeriveDataTypeable, MagicHash #-}
-{-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields -XDeriveGeneric #-}
+{-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields #-}
+
+#if defined(__GLASGOW_HASKELL__)
+{-# LANGUAGE DeriveGeneric #-}
+#endif
 
 module Data.HashMap.Base
     (
@@ -123,7 +127,11 @@ data HashMap k v
     | Leaf !Hash !(Leaf k v)
     | Full !(A.Array (HashMap k v))
     | Collision !Hash !(A.Array (Leaf k v))
+#if defined(__GLASGOW_HASKELL__)
       deriving (Generic, Typeable)
+#else
+      deriving (Typeable)
+#endif
 
 instance (NFData k, NFData v) => NFData (HashMap k v) where
     rnf Empty                 = ()

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, CPP, DeriveDataTypeable, MagicHash #-}
-{-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields #-}
+{-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields -XDeriveGeneric #-}
 
 module Data.HashMap.Base
     (
@@ -97,6 +97,7 @@ import Data.Typeable (Typeable)
 #if defined(__GLASGOW_HASKELL__)
 import Data.Data hiding (Typeable)
 import GHC.Exts ((==#), build, reallyUnsafePtrEquality#)
+import GHC.Generics (Generic)
 #endif
 
 ------------------------------------------------------------------------
@@ -122,7 +123,7 @@ data HashMap k v
     | Leaf !Hash !(Leaf k v)
     | Full !(A.Array (HashMap k v))
     | Collision !Hash !(A.Array (Leaf k v))
-      deriving (Typeable)
+      deriving (Generic, Typeable)
 
 instance (NFData k, NFData v) => NFData (HashMap k v) where
     rnf Empty                 = ()

--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE CPP, DeriveDataTypeable #-}
+{-# OPTIONS_GHC -XDeriveGeneric #-}
+
 
 ------------------------------------------------------------------------
 -- |
@@ -72,12 +74,13 @@ import Data.Typeable (Typeable)
 #if defined(__GLASGOW_HASKELL__)
 import Data.Data hiding (Typeable)
 import GHC.Exts (build)
+import GHC.Generics (Generic)
 #endif
 
 -- | A set of values.  A set cannot contain duplicate values.
 newtype HashSet a = HashSet {
       asMap :: HashMap a ()
-    } deriving (Typeable)
+    } deriving (Generic, Typeable)
 
 instance (NFData a) => NFData (HashSet a) where
     rnf = rnf . asMap

--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP, DeriveDataTypeable #-}
-{-# OPTIONS_GHC -XDeriveGeneric #-}
 
+#if defined(__GLASGOW_HASKELL__)
+{-# LANGUAGE DeriveGeneric #-}
+#endif
 
 ------------------------------------------------------------------------
 -- |
@@ -80,7 +82,11 @@ import GHC.Generics (Generic)
 -- | A set of values.  A set cannot contain duplicate values.
 newtype HashSet a = HashSet {
       asMap :: HashMap a ()
+#if defined(__GLASGOW_HASKELL__)
     } deriving (Generic, Typeable)
+#else
+    } deriving (Typeable)
+#endif
 
 instance (NFData a) => NFData (HashSet a) where
     rnf = rnf . asMap

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -39,6 +39,7 @@ library
   build-depends:
     base >= 4 && < 5,
     deepseq >= 1.1,
+    ghc-prim >= 0.2,
     hashable >= 1.0.1.1
 
   if impl(ghc < 7.4)


### PR DESCRIPTION
Used GHC's "DeriveGeneric" extension to derive Generic instances for HashSets and HashMaps.
