### PR TITLE
Data.HashMap.Array: Hide toList, fromList …

### DIFF
--- a/Data/HashMap/Array.hs
+++ b/Data/HashMap/Array.hs
@@ -52,7 +52,13 @@ import qualified Data.Traversable as Traversable
 import Control.Applicative (Applicative)
 import Control.DeepSeq
 import Control.Monad.ST hiding (runST)
-import GHC.Exts
+-- GHC 7.7 exports toList/fromList from GHC.Exts
+-- In order to avoid warnings on previous GHC versions, we provide
+-- an explicit import list instead of only hiding the offending symbols
+import GHC.Exts ( Array#, Int(..), sizeofArray#, newArray#, copyArray#
+                , readArray#, writeArray#, indexArray#, thawArray#
+                , unsafeFreezeArray#, unsafeThawArray#, MutableArray#
+                , sizeofMutableArray#, copyMutableArray#)
 import GHC.ST (ST(..))
 import Prelude hiding (filter, foldr, length, map, read)
 import qualified Prelude


### PR DESCRIPTION
GHC 7.7 now exports similiarly named members in GHC.Exts
