### PR TITLE
lookupDefault not strict in default value

### DIFF
--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -112,7 +112,7 @@ singleton k !v = HM.singleton k v
 lookupDefault :: (Eq k, Hashable k)
               => v          -- ^ Default value to return.
               -> k -> HashMap k v -> v
-lookupDefault !def k t = HM.lookupDefault def k t
+lookupDefault def k t = HM.lookupDefault def k t
 {-# INLINABLE lookupDefault #-}
 
 -- | /O(log n)/ Associate the specified value with the specified

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -44,8 +44,10 @@ pSingletonValueStrict k = isBottom $ (HM.singleton k (bottom :: Int))
 pLookupDefaultKeyStrict :: Int -> HashMap Key Int -> Bool
 pLookupDefaultKeyStrict def m = isBottom $ HM.lookupDefault def bottom m
 
-pLookupDefaultValueStrict :: Key -> HashMap Key Int -> Bool
-pLookupDefaultValueStrict k m = isBottom $ HM.lookupDefault bottom k m
+pLookupDefaultValueNotStrict :: Key -> HashMap Key Int -> Bool
+pLookupDefaultValueNotStrict k m
+  | k `HM.member` m = not $ isBottom $ HM.lookupDefault bottom k m
+  | otherwise       = isBottom $ HM.lookupDefault bottom k m
 
 pAdjustKeyStrict :: (Int -> Int) -> HashMap Key Int -> Bool
 pAdjustKeyStrict f m = isBottom $ HM.adjust f bottom m
@@ -85,7 +87,7 @@ tests =
       , testProperty "member is key-strict" $ keyStrict HM.member
       , testProperty "lookup is key-strict" $ keyStrict HM.lookup
       , testProperty "lookupDefault is key-strict" pLookupDefaultKeyStrict
-      , testProperty "lookupDefault is value-strict" pLookupDefaultValueStrict
+      , testProperty "lookupDefault is not value-strict" pLookupDefaultValueNotStrict
       , testProperty "! is key-strict" $ keyStrict (flip (HM.!))
       , testProperty "delete is key-strict" $ keyStrict HM.delete
       , testProperty "adjust is key-strict" pAdjustKeyStrict


### PR DESCRIPTION
I don't see any good reason to be strict in the default value of `lookupDefault`. It has nothing to do with the big-oh guarantees that motivate value strictness elsewhere, and defeats its principal use case, which is to _not_ evaluate the potentially expensive fallback unless necessary. You shouldn't run through Plan B before you have even tried Plan A.

See discussion:
http://www.reddit.com/r/haskell/comments/1ker84/destroying_performance_with_strictness/
