### PR TITLE
Adapt module imports to accomodate future `base-4.8`

### DIFF
--- a/Data/HashMap/Array.hs
+++ b/Data/HashMap/Array.hs
@@ -49,7 +49,9 @@ module Data.HashMap.Array
     ) where
 
 import qualified Data.Traversable as Traversable
+#if __GLASGOW_HASKELL__ < 709
 import Control.Applicative (Applicative)
+#endif
 import Control.DeepSeq
 import Control.Monad.ST hiding (runST)
 -- GHC 7.7 exports toList/fromList from GHC.Exts
@@ -59,7 +61,12 @@ import GHC.Exts (Array#, Int(..), newArray#, readArray#, writeArray#,
                  indexArray#, unsafeFreezeArray#, unsafeThawArray#,
                  MutableArray#)
 import GHC.ST (ST(..))
+
+#if __GLASGOW_HASKELL__ >= 709
+import Prelude hiding (filter, foldr, length, map, read, traverse)
+#else
 import Prelude hiding (filter, foldr, length, map, read)
+#endif
 
 #if __GLASGOW_HASKELL__ >= 702
 import GHC.Exts (sizeofArray#, copyArray#, thawArray#, sizeofMutableArray#,

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -81,16 +81,20 @@ module Data.HashMap.Base
     , updateOrConcatWith
     ) where
 
+#if __GLASGOW_HASKELL__ >= 709
+import Data.Functor ((<$>))
+#else
 import Control.Applicative ((<$>), Applicative(pure))
+import Data.Monoid (Monoid(mempty, mappend))
+import Data.Traversable (Traversable(..))
+import Data.Word (Word)
+#endif
 import Control.DeepSeq (NFData(rnf))
 import Control.Monad.ST (ST)
 import Data.Bits ((.&.), (.|.), complement)
 import Data.Data hiding (Typeable)
 import qualified Data.Foldable as Foldable
 import qualified Data.List as L
-import Data.Monoid (Monoid(mempty, mappend))
-import Data.Traversable (Traversable(..))
-import Data.Word (Word)
 import GHC.Exts ((==#), build, reallyUnsafePtrEquality#)
 import Prelude hiding (filter, foldr, lookup, map, null, pred)
 import Text.Read hiding (step)

--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -66,7 +66,9 @@ import Control.DeepSeq (NFData(..))
 import Data.Data hiding (Typeable)
 import Data.HashMap.Base (HashMap, foldrWithKey)
 import Data.Hashable (Hashable)
+#if __GLASGOW_HASKELL__ < 709
 import Data.Monoid (Monoid(..))
+#endif
 import GHC.Exts (build)
 import Prelude hiding (filter, foldr, map, null)
 import qualified Data.Foldable as Foldable


### PR DESCRIPTION
There's only one breaking change in `base-4.8.0.0` so far, namely that
`Prelude` now re-exports `traverse` which clashes with
`Data.HashMap.Array.traverse`. All other changes in this commit are to
avoid redundant-import warnings.
