### PR TITLE
mapAccum

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -754,20 +754,14 @@ map f = mapWithKey (const f)
 {-# INLINE map #-}
 
 -- | /O(n)/. The function 'mapAccum' threads an accumulating
--- argument through the map in ascending order of keys.
+-- argument through the map in some unspecified order of keys.
 mapAccum :: (a -> v1 -> (a,v2)) -> a -> HashMap k v1 -> (a,HashMap k v2)
 mapAccum f = mapAccumWithKey (\a' _ x' -> f a' x')
 
 -- | /O(n)/. The function 'mapAccumWithKey' threads an accumulating
--- argument through the map in ascending order of keys.
+-- argument through the map in some unspecified order of keys.
 mapAccumWithKey :: (a -> k -> v1 -> (a,v2)) -> a -> HashMap k v1 -> (a,HashMap k v2)
-mapAccumWithKey = mapAccumL
-{-# INLINE mapAccumWithKey #-}
-
--- | /O(n)/. The function 'mapAccumL' threads an accumulating 
--- argument through the map in ascending order of keys
-mapAccumL :: (a -> k -> v1 -> (a,v2)) -> a -> HashMap k v1 -> (a,HashMap k v2)
-mapAccumL f = go 
+mapAccumWithKey f = go 
   where
     go a Empty = (a,Empty)
     go a (Leaf h (L k v)) = (a',Leaf h $ L k newAry)
@@ -780,7 +774,7 @@ mapAccumL f = go
       where (!a',!newAry) = A.mapAccum' f' a ary
             f' ai (L k v) = (ai', L k res)
                 where (ai', res) = f ai k v
-{-# INLINE mapAccumL #-}
+{-# INLINE mapAccumWithKey #-}
 
 -- TODO: We should be able to use mutation to create the new
 -- 'HashMap'.

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -292,7 +292,6 @@ lookup k0 m0 = go h0 k0 0 m0
         | otherwise = Nothing
 {-# INLINABLE lookup #-}
 
-
 -- | /O(log n)/ Return the value to which the specified key is mapped,
 -- or the default value if this map contains no mapping for the key.
 lookupDefault :: (Eq k, Hashable k)
@@ -584,6 +583,7 @@ adjust f k0 m0 = go h0 k0 0 m0
         | h == hy   = Collision h (updateWith f k v)
         | otherwise = t
 {-# INLINABLE adjust #-}
+
 
 -- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@, 
 -- (if it is in the map). If (f k x) is @'Nothing', the element is deleted. 

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -21,7 +21,6 @@ module Data.HashMap.Base
     , notMember
     , lookup
     , lookupDefault
-    , findWithDefault
     , (!)
     , insert
     , insertWith
@@ -295,21 +294,13 @@ lookup k0 m0 = go h0 k0 0 m0
 
 -- | /O(log n)/ Return the value to which the specified key is mapped,
 -- or the default value if this map contains no mapping for the key.
-{-# DEPRECATED lookupDefault "renamed to findWithDefault" #-}
 lookupDefault :: (Eq k, Hashable k)
               => v          -- ^ Default value to return.
               -> k -> HashMap k v -> v
-lookupDefault = findWithDefault
-{-# INLINABLE lookupDefault #-}
-
--- | /O(log n)/ The expression (findWithDefault def k map) returns the value at key k or returns default value def when the key is not in the map.
-findWithDefault :: (Eq k, Hashable k)
-                => v          -- ^ Default value to return.
-                -> k -> HashMap k v -> v
-findWithDefault def k t = case lookup k t of
+lookupDefault def k t = case lookup k t of
     Just v -> v
     _      -> def
-{-# INLINABLE findWithDefault #-}
+{-# INLINABLE lookupDefault #-}
 
 -- | /O(log n)/ Return the value to which the specified key is mapped.
 -- Calls 'error' if this map contains no mapping for the key.

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -32,22 +32,37 @@ module Data.HashMap.Lazy
 
       HashMap
 
-      -- * Construction
-    , empty
-    , singleton
+      -- * Operators
+    , (!)
 
-      -- * Basic interface
+      -- * Query
     , HM.null
     , size
     , member
     , HM.lookup
     , lookupDefault
-    , (!)
+    , findWithDefault
+
+      -- * Construction
+    , empty
+    , singleton
+
+      -- * Insertion
     , insert
     , insertWith
+
+    -- * Delete/Update
     , delete
     , adjust
     , alter
+
+      -- * Traversal
+      -- ** Map
+    , HM.map
+    , mapWithKey
+    , traverseWithKey
+    , mapAccum
+    , mapAccumWithKey
 
       -- * Combine
       -- ** Union
@@ -55,20 +70,17 @@ module Data.HashMap.Lazy
     , unionWith
     , unions
 
-      -- * Transformations
-    , HM.map
-    , mapWithKey
-    , traverseWithKey
-
-      -- * Difference and intersection
+      -- ** Difference 
     , difference
+
+      -- ** Intersection
     , intersection
     , intersectionWith
 
       -- * Folds
+    , HM.foldr
     , foldl'
     , foldlWithKey'
-    , HM.foldr
     , foldrWithKey
 
       -- * Filter

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -41,7 +41,6 @@ module Data.HashMap.Lazy
     , member
     , HM.lookup
     , lookupDefault
-    , findWithDefault
 
       -- * Construction
     , empty

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -32,37 +32,24 @@ module Data.HashMap.Lazy
 
       HashMap
 
-      -- * Operators
-    , (!)
-
-      -- * Query
-    , HM.null
-    , size
-    , member
-    , HM.lookup
-    , lookupDefault
-
       -- * Construction
     , empty
     , singleton
 
-      -- * Insertion
+      -- * Basic interface
+    , HM.null
+    , size
+    , member
+    , notMember
+    , HM.lookup
+    , lookupDefault
+    , (!)
     , insert
     , insertWith
-
-    -- * Delete/Update
     , delete
     , adjust
     , update
     , alter
-
-      -- * Traversal
-      -- ** Map
-    , HM.map
-    , mapWithKey
-    , traverseWithKey
-    , mapAccum
-    , mapAccumWithKey
 
       -- * Combine
       -- ** Union
@@ -70,17 +57,22 @@ module Data.HashMap.Lazy
     , unionWith
     , unions
 
-      -- ** Difference 
-    , difference
+      -- * Transformations
+    , HM.map
+    , mapWithKey
+    , traverseWithKey
+    , mapAccum
+    , mapAccumWithKey
 
-      -- ** Intersection
+      -- * Difference and intersection
+    , difference
     , intersection
     , intersectionWith
 
       -- * Folds
-    , HM.foldr
     , foldl'
     , foldlWithKey'
+    , HM.foldr
     , foldrWithKey
 
       -- * Filter

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -32,19 +32,27 @@ module Data.HashMap.Strict
 
       HashMap
 
+      -- * Operators
+    , (!)
+
+      -- * Query
+    , HM.null
+    , size
+    , HM.member
+    , HM.notMember
+    , HM.lookup
+    , lookupDefault
+    , findWithDefault
+
       -- * Construction
     , empty
     , singleton
 
-      -- * Basic interface
-    , HM.null
-    , size
-    , HM.member
-    , HM.lookup
-    , lookupDefault
-    , (!)
+      -- * Insertion
     , insert
     , insertWith
+
+    -- * Delete/Update
     , delete
     , adjust
     , alter
@@ -55,20 +63,25 @@ module Data.HashMap.Strict
     , unionWith
     , unions
 
-      -- * Transformations
-    , map
-    , mapWithKey
-    , traverseWithKey
-
-      -- * Difference and intersection
+      -- ** Difference
     , difference
+
+      -- * Intersection
     , intersection
     , intersectionWith
 
+      -- * Traversal
+      -- ** Map
+    , map
+    , mapWithKey
+    , traverseWithKey
+    , mapAccum
+    , mapAccumWithKey
+
       -- * Folds
+    , HM.foldr
     , foldl'
     , foldlWithKey'
-    , HM.foldr
     , foldrWithKey
 
       -- * Filter

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -42,7 +42,6 @@ module Data.HashMap.Strict
     , HM.notMember
     , HM.lookup
     , lookupDefault
-    , findWithDefault
 
       -- * Construction
     , empty

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -32,26 +32,20 @@ module Data.HashMap.Strict
 
       HashMap
 
-      -- * Operators
-    , (!)
+      -- * Construction
+    , empty
+    , singleton
 
-      -- * Query
+      -- * Basic interface
     , HM.null
     , size
     , HM.member
     , HM.notMember
     , HM.lookup
     , lookupDefault
-
-      -- * Construction
-    , empty
-    , singleton
-
-      -- * Insertion
+    , (!)
     , insert
     , insertWith
-
-    -- * Delete/Update
     , delete
     , adjust
     , update
@@ -63,25 +57,22 @@ module Data.HashMap.Strict
     , unionWith
     , unions
 
-      -- ** Difference
-    , difference
-
-      -- * Intersection
-    , intersection
-    , intersectionWith
-
-      -- * Traversal
-      -- ** Map
+      -- * Transformations
     , map
     , mapWithKey
     , traverseWithKey
     , mapAccum
     , mapAccumWithKey
 
+      -- * Difference and intersection 
+    , difference
+    , intersection
+    , intersectionWith
+
       -- * Folds
-    , HM.foldr
     , foldl'
     , foldlWithKey'
+    , HM.foldr
     , foldrWithKey
 
       -- * Filter

--- a/tests/HashMapProperties.hs
+++ b/tests/HashMapProperties.hs
@@ -127,6 +127,9 @@ pUnions xss = M.toAscList (M.unions (map M.fromList xss)) ==
 pMap :: [(Key, Int)] -> Bool
 pMap = M.map (+ 1) `eq_` HM.map (+ 1)
 
+pMapAccum :: Int -> [(Key, Int)] -> Bool
+pMapAccum n = (M.mapAccum  (\a b -> (a + 1, b+1)) n) `eq'` (HM.mapAccum (\a b -> (a + 1, b+1)) n)
+
 ------------------------------------------------------------------------
 -- ** Difference and intersection
 
@@ -228,6 +231,7 @@ tests =
     , testProperty "unions" pUnions
     -- Transformations
     , testProperty "map" pMap
+    , testProperty "mapAccum" pMapAccum
     -- Folds
     , testGroup "folds"
       [ testProperty "foldr" pFoldr
@@ -268,6 +272,16 @@ eq :: (Eq a, Eq k, Hashable k, Ord k)
    -> [(k, v)]               -- ^ Initial content of the 'HashMap' and 'Model'
    -> Bool                   -- ^ True if the functions are equivalent
 eq f g xs = g (HM.fromList xs) == f (M.fromList xs)
+
+eq' :: (Eq a, Eq k, Eq v, Hashable k, Ord k)
+    => (Model k v -> (a,Model k v))       -- ^ Function that modifies a 'Model'
+    -> (HM.HashMap k v -> (a,HM.HashMap k v))  -- ^ Function that modified a 'HashMap' in the same
+                              -- way
+    -> [(k, v)]               -- ^ Initial content of the 'HashMap' and 'Model'
+    -> Bool                   -- ^ True if the functions are equivalent
+eq' f g xs = (aS == aT) && (M.toAscList t == toAscList s)
+    where (aS,s) = g (HM.fromList xs) 
+          (aT,t) = f (M.fromList xs)
 
 eq_ :: (Eq k, Eq v, Hashable k, Ord k)
     => (Model k v -> Model k v)            -- ^ Function that modifies a 'Model'


### PR DESCRIPTION
This is a part of Issue #89. Ideally, all the functions in container should be provided in unordered-containers. mapAccum has been added with test functions. notMember has also been added since it was trivial to add.
