### PR TITLE
Add haddocks for Semigroup and Monoid instances

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -200,6 +200,8 @@ instance Foldable.Foldable (HashMap k) where
 
 #if __GLASGOW_HASKELL__ >= 711
 -- | '<>' = 'union'
+--
+-- If a key occurs in both maps, the mapping from the first will be the mapping in the result.
 instance (Eq k, Hashable k) => Semigroup (HashMap k v) where
   (<>) = union
   {-# INLINE (<>) #-}
@@ -208,6 +210,8 @@ instance (Eq k, Hashable k) => Semigroup (HashMap k v) where
 -- | 'mempty' = 'empty'
 --
 -- 'mappend' = 'union'
+--
+-- If a key occurs in both maps, the mapping from the first will be the mapping in the result.
 instance (Eq k, Hashable k) => Monoid (HashMap k v) where
   mempty = empty
   {-# INLINE mempty #-}

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -1247,6 +1247,11 @@ alterFEager f !k m = (<$> f mv) $ \fres ->
 
 -- | /O(n+m)/ The union of two maps. If a key occurs in both maps, the
 -- mapping from the first will be the mapping in the result.
+--
+-- ==== __Examples__
+--
+-- >>> union (fromList [(1,'a'),(2,'b')]) (fromList [(2,'c'),(3,'d')])
+-- fromList [(1,'a'),(2,'b'),(3,'d')]
 union :: (Eq k, Hashable k) => HashMap k v -> HashMap k v -> HashMap k v
 union = unionWith const
 {-# INLINABLE union #-}

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -199,11 +199,15 @@ instance Foldable.Foldable (HashMap k) where
     foldr f = foldrWithKey (const f)
 
 #if __GLASGOW_HASKELL__ >= 711
+-- | '<>' = 'union'
 instance (Eq k, Hashable k) => Semigroup (HashMap k v) where
   (<>) = union
   {-# INLINE (<>) #-}
 #endif
 
+-- | 'mempty' = 'empty'
+--
+-- 'mappend' = 'union'
 instance (Eq k, Hashable k) => Monoid (HashMap k v) where
   mempty = empty
   {-# INLINE mempty #-}

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -202,6 +202,11 @@ instance Foldable.Foldable (HashMap k) where
 -- | '<>' = 'union'
 --
 -- If a key occurs in both maps, the mapping from the first will be the mapping in the result.
+--
+-- ==== __Examples__
+--
+-- >>> fromList [(1,'a'),(2,'b')] <> fromList [(2,'c'),(3,'d')]
+-- fromList [(1,'a'),(2,'b'),(3,'d')]
 instance (Eq k, Hashable k) => Semigroup (HashMap k v) where
   (<>) = union
   {-# INLINE (<>) #-}
@@ -212,6 +217,11 @@ instance (Eq k, Hashable k) => Semigroup (HashMap k v) where
 -- 'mappend' = 'union'
 --
 -- If a key occurs in both maps, the mapping from the first will be the mapping in the result.
+--
+-- ==== __Examples__
+--
+-- >>> mappend (fromList [(1,'a'),(2,'b')]) (fromList [(2,'c'),(3,'d')])
+-- fromList [(1,'a'),(2,'b'),(3,'d')]
 instance (Eq k, Hashable k) => Monoid (HashMap k v) where
   mempty = empty
   {-# INLINE mempty #-}

--- a/Data/HashSet/Base.hs
+++ b/Data/HashSet/Base.hs
@@ -239,6 +239,11 @@ keysSet m = fromMap (() <$ m)
 --
 -- To obtain good performance, the smaller set must be presented as
 -- the first argument.
+--
+-- ==== __Examples__
+--
+-- >>> union (fromList [1,2]) (fromList [2,3])
+-- fromList [1,2,3]
 union :: (Eq a, Hashable a) => HashSet a -> HashSet a -> HashSet a
 union s1 s2 = HashSet $ H.union (asMap s1) (asMap s2)
 {-# INLINE union #-}

--- a/Data/HashSet/Base.hs
+++ b/Data/HashSet/Base.hs
@@ -142,11 +142,15 @@ instance Foldable.Foldable HashSet where
     {-# INLINE foldr #-}
 
 #if __GLASGOW_HASKELL__ >= 711
+-- | '<>' = 'union'
 instance (Hashable a, Eq a) => Semigroup (HashSet a) where
     (<>) = union
     {-# INLINE (<>) #-}
 #endif
 
+-- | 'mempty' = 'empty'
+--
+-- 'mappend' = 'union'
 instance (Hashable a, Eq a) => Monoid (HashSet a) where
     mempty = empty
     {-# INLINE mempty #-}

--- a/Data/HashSet/Base.hs
+++ b/Data/HashSet/Base.hs
@@ -143,6 +143,11 @@ instance Foldable.Foldable HashSet where
 
 #if __GLASGOW_HASKELL__ >= 711
 -- | '<>' = 'union'
+--
+-- /O(n+m)/
+--
+-- To obtain good performance, the smaller set must be presented as
+-- the first argument.
 instance (Hashable a, Eq a) => Semigroup (HashSet a) where
     (<>) = union
     {-# INLINE (<>) #-}
@@ -151,6 +156,11 @@ instance (Hashable a, Eq a) => Semigroup (HashSet a) where
 -- | 'mempty' = 'empty'
 --
 -- 'mappend' = 'union'
+--
+-- /O(n+m)/
+--
+-- To obtain good performance, the smaller set must be presented as
+-- the first argument.
 instance (Hashable a, Eq a) => Monoid (HashSet a) where
     mempty = empty
     {-# INLINE mempty #-}

--- a/Data/HashSet/Base.hs
+++ b/Data/HashSet/Base.hs
@@ -148,6 +148,11 @@ instance Foldable.Foldable HashSet where
 --
 -- To obtain good performance, the smaller set must be presented as
 -- the first argument.
+--
+-- ==== __Examples__
+--
+-- >>> fromList [1,2] <> fromList [2,3]
+-- fromList [1,2,3]
 instance (Hashable a, Eq a) => Semigroup (HashSet a) where
     (<>) = union
     {-# INLINE (<>) #-}
@@ -161,6 +166,11 @@ instance (Hashable a, Eq a) => Semigroup (HashSet a) where
 --
 -- To obtain good performance, the smaller set must be presented as
 -- the first argument.
+--
+-- ==== __Examples__
+--
+-- >>> mappend (fromList [1,2]) (fromList [2,3])
+-- fromList [1,2,3]
 instance (Hashable a, Eq a) => Monoid (HashSet a) where
     mempty = empty
     {-# INLINE mempty #-}


### PR DESCRIPTION
Since there is more than one reasonable choice of `mappend` implementation for `HashMap` and `HashSet`, it seems important for there to be some documentation on which one was selected.