### PR TITLE
Make the benchmark suite buildable with cabal new-build. 

### DIFF
--- a/benchmarks/unordered-containers-benchmarks.cabal
+++ b/benchmarks/unordered-containers-benchmarks.cabal
@@ -5,21 +5,10 @@ build-type: Simple
 cabal-version: >=1.2
 
 executable unordered-containers-benchmarks
-  ghc-options: -Wall -O2
-  cc-options: -msse4.1
-  c-sources:
-    ../cbits/popc.c
-  hs-source-dirs: .. .
+  ghc-options: -Wall -O2 -rtsopts
+  hs-source-dirs: .
   main-is: Benchmarks.hs
   other-modules:
-    Data.HashMap.Array
-    Data.HashMap.Base
-    Data.HashMap.Lazy
-    Data.HashMap.PopCount
-    Data.HashMap.Strict
-    Data.HashMap.Unsafe
-    Data.HashMap.UnsafeShift
-    Data.HashSet
     Util.ByteString
     Util.Int
     Util.String
@@ -34,4 +23,5 @@ executable unordered-containers-benchmarks
     ghc-prim,
     hashable,
     mtl,
-    random
+    random,
+    unordered-containers

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: . ./benchmarks

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -174,45 +174,6 @@ test-suite strictness-properties
   ghc-options: -Wall
   cpp-options: -DASSERTS
 
-benchmark benchmarks
-  -- We cannot depend on the unordered-containers library directly as
-  -- that creates a dependency cycle.
-  hs-source-dirs: . benchmarks
-
-  main-is: Benchmarks.hs
-  type: exitcode-stdio-1.0
-
-  other-modules:
-    Data.HashMap.Array
-    Data.HashMap.Base
-    Data.HashMap.Lazy
-    Data.HashMap.Strict
-    Data.HashMap.Strict.Base
-    Data.HashMap.Unsafe
-    Data.HashMap.UnsafeShift
-    Data.HashSet
-    Data.HashSet.Base
-    Util.ByteString
-    Util.Int
-    Util.String
-
-  build-depends:
-    base >= 4.8.0,
-    bytestring,
-    containers,
-    criterion >= 1.0 && < 1.3,
-    deepseq >= 1.1,
-    deepseq-generics,
-    hashable >= 1.0.1.1,
-    hashmap,
-    mtl,
-    random
-
-  default-language: Haskell2010
-  ghc-options: -Wall -O2 -rtsopts -fwarn-tabs -ferror-spans
-  if flag(debug)
-    cpp-options: -DASSERTS
-
 source-repository head
   type:     git
   location: https://github.com/tibbe/unordered-containers.git


### PR DESCRIPTION
This commit also cleans up the cabal-related part of the benchmark suite. There were previously two copies of it. The cabal benchmarks section in the main cabal file for the library itself was unbuildable
because of cyclic dependencies. The cabal file in the benchmarks directory was also broken with cabal new-build, but it was less broken. This was changed to simply depend on unordered-containers, and now it works fine. This will result in more unnecessary rebuilding when building the benchmarks, but at least it works.