### PR TITLE
Made the new function in Data.HashMap.Array stricter.

### DIFF
--- a/Data/HashMap/Array.hs
+++ b/Data/HashMap/Array.hs
@@ -245,7 +245,7 @@ rnfArray ary0 = go ary0 n0 0
 -- state thread, with each element containing the specified initial
 -- value.
 new :: Int -> a -> ST s (MArray s a)
-new n@(I# n#) b =
+new n@(I# n#) !b =
     CHECK_GT("new",n,(0 :: Int))
     ST $ \s ->
         case newArray# n# b s of
@@ -253,7 +253,11 @@ new n@(I# n#) b =
 {-# INLINE new #-}
 
 new_ :: Int -> ST s (MArray s a)
-new_ n = new n undefinedElem
+new_ n@(I# n#) =
+  CHECK_GT("new",n,(0 :: Int))
+  ST $ \s ->
+     case newArray# n# undefinedElem s of
+       (# s', ary #) -> (# s', marray ary n #)
 
 singleton :: a -> Array a
 singleton x = runST (singletonM x)


### PR DESCRIPTION
The `new` function is now strict in the value that will fill the array:

```
new :: Int -> a -> ST s (MArray s a)
new n@(I# n#) !b =
```

This avoids creating an extra thunk when calling `new`, which we can see by looking at the STG generated by uses of `HashMap`. Here is an excerpt from the `HashMapProperties` module, related to the `collision` function. Without this PR, we get the following STG:

```
case eqWord# [x_sH5j y_sH5n] of {
  __DEFAULT ->
   let {
  sat_sH5u =
   \u []
    case w_sH5d of nt_sH5s {
      I# _ ->
       Leaf [ww1_sH5c
       nt_sH5s
       w1_sH5e];
    };
   } in
  case
   newSmallArray# [2#
       sat_sH5u
       w4_sH5i]
  of
```

`sat_sH5u`, passed to `newSmallArray#` is a thunk. With the added strictness, we can avoid the thunk here:

```
case eqWord# [x_sH9s y_sH9w] of {
  __DEFAULT ->
   let {
  sat_sH9B = CCCS I#! [ww2_sH9m]; } in
   let {
  sat_sH9C =
   CCCS Leaf! [ww1_sH9l
      sat_sH9B
      w_sH9n];
   } in
  case
   newSmallArray# [2#
       sat_sH9C
       w3_sH9r]
  of
```

(Note how `sat_sH9C` is not a thunk in this version of the code.)

I'm not sure whether this is an immediate problem in the current version of the library, but it definitely has the potential to cause space leaks in the future. This change makes the strictness behavior of the data structure more internally consistent.

To keep the behavior of `new_` unchanged (which depends on a lazy `new` for error handling), we inlined the body of `new` into `new_`. I'm not sure if there's a better solution—can we do away with `undefinedElem` altogether?

It probably makes sense to make a few other `Array` operations like `write` strict as well, but I haven't looked at them too closely.