### PR TITLE
Avoid boxing arrays

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -200,7 +200,7 @@ benchmark benchmarks
     base >= 4.8.0,
     bytestring,
     containers,
-    criterion >= 1.0 && < 1.3,
+    criterion >= 1.0,
     deepseq >= 1.1,
     deepseq-generics,
     hashable >= 1.0.1.1,


### PR DESCRIPTION
Previously, we used a lot of things that looked like

    runST (act >>= unsafeFreeze)

The trouble is that GHC can't unbox past the `runRW#` primitive
that `runST` is based on. So this actually allocates an `Array`
constructor which we will then throw away immediately.

The way to avoid this is to call `runRW#` manually to produce
a raw `SmallArray#`, then apply the `Array` constructor on the
outside.