### PR TITLE
Fix inaccurate and badly formatted docs for update

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -1126,9 +1126,9 @@ adjust# f k0 m0 = go h0 k0 0 m0
         | otherwise = t
 {-# INLINABLE adjust# #-}
 
--- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@
--- (if it is in the map). If (@f x@) is @'Nothing'@, the element is deleted.
--- If it is (@'Just' y@), the key @k@ is bound to the new value @y@.
+-- | /O(log n)/  The expression @('update' f k map)@ updates the value @x@ at @k@
+-- (if it is in the map). If @(f x)@ is 'Nothing', the element is deleted.
+-- If it is @('Just' y)@, the key @k@ is bound to the new value @y@.
 update :: (Eq k, Hashable k) => (a -> Maybe a) -> k -> HashMap k a -> HashMap k a
 update f = alter (>>= f)
 {-# INLINABLE update #-}

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -1126,9 +1126,9 @@ adjust# f k0 m0 = go h0 k0 0 m0
         | otherwise = t
 {-# INLINABLE adjust# #-}
 
--- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@,
--- (if it is in the map). If (f k x) is @'Nothing', the element is deleted.
--- If it is (@'Just' y), the key k is bound to the new value y.
+-- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@
+-- (if it is in the map). If (@f x@) is @'Nothing'@, the element is deleted.
+-- If it is (@'Just' y@), the key @k@ is bound to the new value @y@.
 update :: (Eq k, Hashable k) => (a -> Maybe a) -> k -> HashMap k a -> HashMap k a
 update f = alter (>>= f)
 {-# INLINABLE update #-}

--- a/Data/HashMap/Strict/Base.hs
+++ b/Data/HashMap/Strict/Base.hs
@@ -244,9 +244,9 @@ adjust f k0 m0 = go h0 k0 0 m0
         | otherwise = t
 {-# INLINABLE adjust #-}
 
--- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@,
--- (if it is in the map). If (f k x) is @'Nothing', the element is deleted.
--- If it is (@'Just' y), the key k is bound to the new value y.
+-- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@
+-- (if it is in the map). If (@f x@) is @'Nothing'@, the element is deleted.
+-- If it is (@'Just' y@), the key @k@ is bound to the new value @y@.
 update :: (Eq k, Hashable k) => (a -> Maybe a) -> k -> HashMap k a -> HashMap k a
 update f = alter (>>= f)
 {-# INLINABLE update #-}

--- a/Data/HashMap/Strict/Base.hs
+++ b/Data/HashMap/Strict/Base.hs
@@ -244,9 +244,9 @@ adjust f k0 m0 = go h0 k0 0 m0
         | otherwise = t
 {-# INLINABLE adjust #-}
 
--- | /O(log n)/  The expression (@'update' f k map@) updates the value @x@ at @k@
--- (if it is in the map). If (@f x@) is @'Nothing'@, the element is deleted.
--- If it is (@'Just' y@), the key @k@ is bound to the new value @y@.
+-- | /O(log n)/  The expression @('update' f k map)@ updates the value @x@ at @k@
+-- (if it is in the map). If @(f x)@ is 'Nothing', the element is deleted.
+-- If it is @('Just' y)@, the key @k@ is bound to the new value @y@.
 update :: (Eq k, Hashable k) => (a -> Maybe a) -> k -> HashMap k a -> HashMap k a
 update f = alter (>>= f)
 {-# INLINABLE update #-}


### PR DESCRIPTION
Previously the docs suggested that the update function received the key
as well as the value, but actually it only gets the value.