### PR TITLE
Add missing doc about strictness

### DIFF
--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -101,4 +101,4 @@ import Prelude ()
 --
 -- This module satisfies the following strictness property:
 --
--- * Key arguments are evaluated to WHNF
+-- * Key arguments are evaluated to WHNF.

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -95,3 +95,12 @@ module Data.HashMap.Strict
 import Data.HashMap.Strict.Base as HM
 import qualified Data.HashSet.Base as HS
 import Prelude ()
+
+-- $strictness
+--
+-- This module satisfies the following strictness properties:
+--
+-- 1. Key arguments are evaluated to WHNF;
+--
+-- 2. Keys and values are evaluated to WHNF before they are stored in
+--    the map.


### PR DESCRIPTION
Copied the `$strictness` chunk from in `Data.HashMap.Strict.Base` because they are not imported across modules.

Haddock emitted a warning about this, which is how I caught this.