### PR TITLE
proposed rewording of the Ord instance documentation

### DIFF
--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -352,12 +352,9 @@ instance Ord k => Ord1 (HashMap k) where
     liftCompare = cmp compare
 #endif
 
--- | The order is total.
---
--- /Note:/ The ordering of elements in 'HashMap' depends primarily on the keys'
--- hashes. Therefore, it inherits any of the properties of the hashes. In
--- particular, if the hash in use is inconsistent between library versions,
--- OSes or architectures, then the ordering will reflect these inconsistencies. 
+-- | The ordering is total and consistent with the `Eq` instance. However,
+-- nothing else about the ordering is specified, and it may change from 
+-- version to version of either this package or of hashable.
 instance (Ord k, Ord v) => Ord (HashMap k v) where
     compare = cmp compare compare
 

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -354,9 +354,11 @@ instance Ord k => Ord1 (HashMap k) where
 
 -- | The order is total.
 --
--- /Note:/ Note: The actual order of elements in 'HashMap' and the result of
--- `compare` may not b consistent because the hash is not guaranteed to be
--- consistent across library versions, OSes and architectures
+-- /Note:/ The ordering of elements in 'HashMap' depends primarily on the keys'
+-- hashes. Therefore, it inherits any of the properties of the hashes. In
+-- particular, if the hash in use is inconsistent between library versions,
+-- OSes or architectures, then the ordering will be inconsistent in the same
+-- circumstance.
 instance (Ord k, Ord v) => Ord (HashMap k v) where
     compare = cmp compare compare
 

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -354,9 +354,9 @@ instance Ord k => Ord1 (HashMap k) where
 
 -- | The order is total.
 --
--- /Note:/ Because the hash is not guaranteed to be stable across library
--- versions, OSes, or architectures, neither is an actual order of elements in
--- 'HashMap' or an result of `compare`.is stable.
+-- /Note:/ Note: The actual order of elements in 'HashMap' and the result of
+-- `compare` may not b consistent because the hash is not guaranteed to be
+-- consistent across library versions, OSes and architectures
 instance (Ord k, Ord v) => Ord (HashMap k v) where
     compare = cmp compare compare
 

--- a/Data/HashMap/Base.hs
+++ b/Data/HashMap/Base.hs
@@ -357,8 +357,7 @@ instance Ord k => Ord1 (HashMap k) where
 -- /Note:/ The ordering of elements in 'HashMap' depends primarily on the keys'
 -- hashes. Therefore, it inherits any of the properties of the hashes. In
 -- particular, if the hash in use is inconsistent between library versions,
--- OSes or architectures, then the ordering will be inconsistent in the same
--- circumstance.
+-- OSes or architectures, then the ordering will reflect these inconsistencies. 
 instance (Ord k, Ord v) => Ord (HashMap k v) where
     compare = cmp compare compare
 


### PR DESCRIPTION
Re issue #250 

The Ord instance for HashMap depends on:

* toList', which flattens(?) the HashMap into a list of Leafs and Collisions
* The Semigroup instance for Ordering:
```
instance Semigroup Ordering where
    LT <> _ = LT
    EQ <> y = y
    GT <> _ = GT
```
Therefore, the ordering of two hashmaps depends on the ordering of the first non-equal pair.

Concerning the comparison:
* If the elements being compared are both Leafs, then the hashes are compared and if EQ, the keys are compared and if EQ, the values are compared.
* If the elements being compared are both Collisions, then the hashes are compared and if EQ, the key/value array is compared for length, and if EQ, then it uses unorderedCompare to compare the key/value pairs.
* A Leaf is less than a Collision, and a Collision is greater than a Leaf. 

I assume that the entry that will be the first entry will also depend on the hash.

Therefore, the ordering depends primarily on the hash. 

So it seems to me that the note intends to communicate:

> /Note:/ The ordering of elements in 'HashMap' depends primarily on the keys' hashes. Therefore, it inherits any of the properties of the hashes. In particular, if the hash in use is inconsistent between library versions, OSes or architectures, then the ordering will be inconsistent in the same circumstance.

I have included this proposed rewording in the documentation. I think it is good to call out that it depends primarily on the hash, since the instance is `(Ord k, Ord v) => Ord (HashMap k v)`. A person who reads this might think "oh, it is using the keys and values to determine the order", whereas in reality it is only using the keys and values to determine the order of two hashmaps whose early entries have the same hash but different keys or values. I suppose this isn't so unlikely, but it isn't as important as the conditions on the instance might make you think.

An alternative rewording was included in the original bug report. It is included here with modifications: 

> The actual order of elements in 'HashMap' and the result of
> `compare` may not b consistent because the hash is not guaranteed to be
> consistent across library versions, OSes and architectures

The main change here is that I have changed the word "stable" for "consistent", since I don't believe the author had in mind stability as it is usually understood in ordering (i.e. if you sort a sorted list of hashmaps, it is unchanged). The reference to library versions, OSes and architectures, as well as the hash, makes me believe the original author had it mind the possibility that automatically derived instances of Data.Hashable may change from version to version. (Is that true? It strikes me as a little surprising.)

I don't have a strong understanding of this library or `hashable`. I haven't actually used either - I came across this documentation while trying to understand another library.