### PR TITLE
Fast inclusion operation on hashmaps and hashsets

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -150,7 +150,7 @@ import qualified Data.Foldable as Foldable
 import Data.Bifoldable
 #endif
 import qualified Data.List as L
-import GHC.Exts ((==#), build, reallyUnsafePtrEquality#)
+import GHC.Exts ((==#), build, reallyUnsafePtrEquality#, inline)
 import Prelude hiding (filter, foldl, foldr, lookup, map, null, pred)
 import Text.Read hiding (step)
 
@@ -1431,8 +1431,8 @@ alterFEager f !k m = (<$> f mv) $ \fres ->
 -- >>> fromList [(1,'a'),(2,'b')] `isSubmapOf` fromList [(1,'a')]
 -- False
 isSubmapOf :: (Eq k, Hashable k, Eq v) => HashMap k v -> HashMap k v -> Bool
-isSubmapOf = isSubmapOfBy (==)
-{-# INLINE isSubmapOf #-}
+isSubmapOf = (inline isSubmapOfBy) (==)
+{-# INLINABLE isSubmapOf #-}
 
 -- | /O(n*log m)/ Inclusion of maps with value comparison. A map is included in
 -- another map if the keys are subsets and if the comparison function is true
@@ -1502,6 +1502,7 @@ isSubmapOfBy comp !m1 !m2 = go 0 m1 m2
     go _ (BitmapIndexed {}) (Collision {}) = False
     go _ (Full {}) (Collision {}) = False
     go _ (Full {}) (BitmapIndexed {}) = False
+{-# INLINABLE isSubmapOfBy #-}
 
 -- | /O(min n m))/ Checks if a bitmap indexed node is a submap of another.
 submapBitmapIndexed :: (HashMap k v1 -> HashMap k v2 -> Bool) -> Bitmap -> A.Array (HashMap k v1) -> Bitmap -> A.Array (HashMap k v2) -> Bool
@@ -1525,6 +1526,7 @@ submapBitmapIndexed comp !b1 !ary1 !b2 !ary2 = subsetBitmaps && go 0 0 (b1Orb2 .
     b1Andb2 = b1 .&. b2
     b1Orb2  = b1 .|. b2
     subsetBitmaps = b1Orb2 == b2
+{-# INLINABLE submapBitmapIndexed #-}
 
 ------------------------------------------------------------------------
 -- * Combine

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -669,6 +669,10 @@ lookupRecordCollision h k m = lookupCont (\_ -> Absent) Present h k 0 m
 -- so we can be representation-polymorphic in the result type. Since
 -- this whole thing is always inlined, we don't have to worry about
 -- any extra CPS overhead.
+--
+-- The @Int@ argument is the offset of the subkey in the hash. When looking up
+-- keys at the top-level of a hashmap, the offset should be 0. When looking up
+-- keys at level @n@ of a hashmap, the offset should be @n * bitsPerSubkey@.
 lookupCont ::
 #if __GLASGOW_HASKELL__ >= 802
   forall rep (r :: TYPE rep) k v.
@@ -680,7 +684,7 @@ lookupCont ::
   -> (v -> Int -> r) -- Present continuation
   -> Hash -- The hash of the key
   -> k
-  -> Int -- The subkey
+  -> Int -- The offset of the subkey in the hash.
   -> HashMap k v -> r
 lookupCont absent present !h0 !k0 !s0 !m0 = go h0 k0 s0 m0
   where

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1422,15 +1422,18 @@ alterFEager f !k m = (<$> f mv) $ \fres ->
 --
 -- >>> isSubmapOf m1 m2 = keys m1 ⊆ keys m2 && and [ v1 == v2 | (k1,v1) <- toList m1; let v2 = m2 ! k1 ]
 --
--- This defines a partial order on maps, for which 'union' is the least upper bound.
--- More specifically, @isSubmapOf m1 (union m1 m2)@ and @isSubmapOf m2 (union m1 m2)@.
+-- This defines a partial order on maps. However, 'union' is /not/ its least
+-- upper bound, because it is not cummutative. In particular, for all maps @m1@
+-- and @m2@ it holds @m1 `isSubmapOf` union m1 m2@, however, the other direction
+-- @m2 `isSubmapOf` union m1 m2@ may not hold because 'union' may discard values
+-- of m2.
 --
 -- ==== __Examples__
 --
--- >>> isSubmapOf (fromList [(1,'a')]) (fromList [(1,'a'),(2,'b')])
+-- >>> fromList [(1,'a')] `isSubmapOf` fromList [(1,'a'),(2,'b')]
 -- True
 --
--- >>> isSubmapOf (fromList [(1,'a'),(2,'b')]) (fromList [(1,'a')])
+-- >>> fromList [(1,'a'),(2,'b')] `isSubmapOf` fromList [(1,'a')]
 -- False
 isSubmapOf :: (Eq k, Hashable k, Eq v) => HashMap k v -> HashMap k v -> Bool
 isSubmapOf = isSubmapOfBy (==)
@@ -1441,8 +1444,11 @@ isSubmapOf = isSubmapOfBy (==)
 --
 -- >>> isSubmapOfBy (⊑) m1 m2 = keys m1 ⊆ keys m2 && and [ v1 ⊑ v2 | (k1,v1) <- toList m1; let v2 = m2 ! k1 ]
 --
--- This defines a partial order on maps, for which 'unionWith' is the least upper bound.
--- More specifically, @isSubmapOfBy (⊑) m1 (unionWith (⊔) m1 m2)@ and @isSubmapOfBy (⊑) m2 (unionWith (⊔) m1 m2)@.
+-- This defines a partial order on maps, for which 'unionWith' is the least
+-- upper bound. More specifically, let @(⊑)@ be a partial order on values for
+-- which @(⊔)@ is the least upper bound. Then for all maps @m1@ and @m2@ it
+-- holds @isSubmapOfBy (⊑) m1 (unionWith (⊔) m1 m2)@ and
+-- @isSubmapOfBy (⊑) m2 (unionWith (⊔) m1 m2)@.
 isSubmapOfBy :: (Eq k, Hashable k) => (v1 -> v2 -> Bool) -> HashMap k v1 -> HashMap k v2 -> Bool
 isSubmapOfBy comp = go 0
   where

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1450,6 +1450,16 @@ isSubmapOf = isSubmapOfBy (==)
 -- holds @isSubmapOfBy (⊑) m1 (unionWith (⊔) m1 m2)@ and
 -- @isSubmapOfBy (⊑) m2 (unionWith (⊔) m1 m2)@.
 isSubmapOfBy :: (Eq k, Hashable k) => (v1 -> v2 -> Bool) -> HashMap k v1 -> HashMap k v2 -> Bool
+-- O(n*m) is the worst case runtime complexity. The worst case is when both
+-- hashmaps m1 and m2 are collision nodes. Since collision nodes are unsorted
+-- arrays, it requires for every key in m1 a linear search to to find a matching
+-- key in m2, hence O(n*m).
+--
+-- For maps without collisions the complexity is O(n), where n is the size of
+-- m1: the inclusion operation traverses both maps in synchrony. When it
+-- traverses down an edge in m1, it selects the appropriate edge in m2 with the
+-- same hash prefix. Furthermore, it only needs to visit each node in m1 once.
+-- Therefore, the complexity is O(n).
 isSubmapOfBy comp = go 0
   where
     -- An empty map is always a submap of any other map.

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1465,6 +1465,9 @@ isSubmapOfBy comp = go 0
     -- An empty map is always a submap of any other map.
     go !_ Empty _ = True
 
+    -- If the second map is empty and the first is not, it cannot be a submap.
+    go _ _ Empty = False
+
     -- If the first map contains only one entry, lookup the key in the second map.
     go s (Leaf h1 (L k1 v1)) t2 = lookupCont (\_ -> False) (\v2 _ -> comp v1 v2) h1 k1 s t2
 
@@ -1500,12 +1503,6 @@ isSubmapOfBy comp = go 0
       submapBitmapIndexed (go (s+bitsPerSubkey)) fullNodeMask ls1 fullNodeMask ls2
     go s (Full ls1) (BitmapIndexed b2 ls2) =
       submapBitmapIndexed (go (s+bitsPerSubkey)) fullNodeMask ls1 b2 ls2
-
-    -- TODO: I'm not sure about these cases and need help. If we cleared up all
-    -- these cases, we can replace them with a catch-all case go _ _ _ = False
-
-    -- If the second map is empty and the first is not, it cannot be a submap.
-    go _ _ Empty = False
 
     -- A collision, bitmap indexed an full node always contain at least two
     -- entries. Hence it cannot be a map of a leaf.

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1457,10 +1457,10 @@ isSubmapOfBy :: (Eq k, Hashable k) => (v1 -> v2 -> Bool) -> HashMap k v1 -> Hash
 -- and m2 are collision nodes for the same hash. Since collision nodes are
 -- unsorted arrays, it requires for every key in m1 a linear search to to find a
 -- matching key in m2, hence O(n*m).
-isSubmapOfBy comp = go 0
+isSubmapOfBy comp !m1 !m2 = go 0 m1 m2
   where
     -- An empty map is always a submap of any other map.
-    go !_ Empty _ = True
+    go _ Empty _ = True
 
     -- If the second map is empty and the first is not, it cannot be a submap.
     go _ _ Empty = False
@@ -1505,10 +1505,10 @@ isSubmapOfBy comp = go 0
 
 -- | /O(min n m))/ Checks if a bitmap indexed node is a submap of another.
 submapBitmapIndexed :: (HashMap k v1 -> HashMap k v2 -> Bool) -> Bitmap -> A.Array (HashMap k v1) -> Bitmap -> A.Array (HashMap k v2) -> Bool
-submapBitmapIndexed comp b1 ary1 b2 ary2 = subsetBitmaps && go 0 0 (b1Orb2 .&. negate b1Orb2)
+submapBitmapIndexed comp !b1 !ary1 !b2 !ary2 = subsetBitmaps && go 0 0 (b1Orb2 .&. negate b1Orb2)
   where
     go :: Int -> Int -> Bitmap -> Bool
-    go i j m
+    go !i !j !m
       | m > b1Orb2 = True
 
       -- In case a key is both in ary1 and ary2, check ary1[i] <= ary2[j] and

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1476,7 +1476,7 @@ isSubmapOfBy comp = go 0
     go _ (Collision h1 ls1) (Collision h2 ls2) =
       h1 == h2 && subsetArray comp ls1 ls2
 
-    -- To check ls1 ⊆ ls2, we only need to check the entries in ls2 with the hash h1.
+    -- To check t1 ⊆ t2, we only need to check the entries in ls2 with the hash h1.
     go s t1@(Collision h1 _) (BitmapIndexed b ls2)
         | b .&. m == 0 = False
         | otherwise    =
@@ -1493,7 +1493,7 @@ isSubmapOfBy comp = go 0
     go s t1@(Full {}) t2@(Collision h2 _) =
       go s t1 (BitmapIndexed (mask h2 s) (A.singleton t2))
 
-    -- In cases where the first and second map are bitmap indexed or full,
+    -- In cases where the first and second map are BitmapIndexed or Full,
     -- traverse down the tree at the appropriate indices.
     go s (BitmapIndexed b1 ls1) (BitmapIndexed b2 ls2) =
       submapBitmapIndexed (go (s+bitsPerSubkey)) b1 ls1 b2 ls2

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1458,8 +1458,8 @@ isSubmapOfBy :: (Eq k, Hashable k) => (v1 -> v2 -> Bool) -> HashMap k v1 -> Hash
 -- For maps without collisions the complexity is O(n), where n is the size of
 -- m1: the inclusion operation traverses both maps in synchrony. When it
 -- traverses down an edge in m1, it selects the appropriate edge in m2 with the
--- same hash prefix. Furthermore, it only needs to visit each node in m1 once.
--- Therefore, the complexity is O(n).
+-- same hash prefix. Furthermore, it only needs to visit each node in m1 and m2
+-- once. Therefore, the complexity is O(n).
 isSubmapOfBy comp = go 0
   where
     -- An empty map is always a submap of any other map.
@@ -1471,12 +1471,12 @@ isSubmapOfBy comp = go 0
     -- If the first map contains only one entry, lookup the key in the second map.
     go s (Leaf h1 (L k1 v1)) t2 = lookupCont (\_ -> False) (\v2 _ -> comp v1 v2) h1 k1 s t2
 
-    -- In this case we need to check that for each x in ls1, there is a y in ls2
+    -- In this case, we need to check that for each x in ls1, there is a y in ls2
     -- such that x ⊑ y. This is the worst case complexity-wise since it requires a O(m*n) check.
     go _ (Collision h1 ls1) (Collision h2 ls2) =
       h1 == h2 && subsetArray comp ls1 ls2
 
-    -- To check t1 ⊆ t2, we only need to check the entries in ls2 with the hash h1.
+    -- In this case, we only need to check the entries in ls2 with the hash h1.
     go s t1@(Collision h1 _) (BitmapIndexed b ls2)
         | b .&. m == 0 = False
         | otherwise    =

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -49,6 +49,8 @@ module Data.HashMap.Internal
     , update
     , alter
     , alterF
+    , subset
+    , subsetWith
 
       -- * Combine
       -- ** Union
@@ -590,12 +592,12 @@ lookup k m = case lookup# k m of
 {-# INLINE lookup #-}
 
 lookup# :: (Eq k, Hashable k) => k -> HashMap k v -> (# (# #) | v #)
-lookup# k m = lookupCont (\_ -> (# (# #) | #)) (\v _i -> (# | v #)) (hash k) k m
+lookup# k m = lookupCont (\_ -> (# (# #) | #)) (\v _i -> (# | v #)) (hash k) k 0 m
 {-# INLINABLE lookup# #-}
 
 #else
 
-lookup k m = lookupCont (\_ -> Nothing) (\v _i -> Just v) (hash k) k m
+lookup k m = lookupCont (\_ -> Nothing) (\v _i -> Just v) (hash k) k 0 m
 {-# INLINABLE lookup #-}
 #endif
 
@@ -614,7 +616,7 @@ lookup' h k m = case lookupRecordCollision# h k m of
   (# | (# a, _i #) #) -> Just a
 {-# INLINE lookup' #-}
 #else
-lookup' h k m = lookupCont (\_ -> Nothing) (\v _i -> Just v) h k m
+lookup' h k m = lookupCont (\_ -> Nothing) (\v _i -> Just v) h k 0 m
 {-# INLINABLE lookup' #-}
 #endif
 
@@ -649,13 +651,13 @@ lookupRecordCollision h k m = case lookupRecordCollision# h k m of
 -- into lookupCont because inlining takes care of that.
 lookupRecordCollision# :: Eq k => Hash -> k -> HashMap k v -> (# (# #) | (# v, Int# #) #)
 lookupRecordCollision# h k m =
-    lookupCont (\_ -> (# (# #) | #)) (\v (I# i) -> (# | (# v, i #) #)) h k m
+    lookupCont (\_ -> (# (# #) | #)) (\v (I# i) -> (# | (# v, i #) #)) h k 0 m
 -- INLINABLE to specialize to the Eq instance.
 {-# INLINABLE lookupRecordCollision# #-}
 
 #else /* GHC < 8.2 so there are no unboxed sums */
 
-lookupRecordCollision h k m = lookupCont (\_ -> Absent) Present h k m
+lookupRecordCollision h k m = lookupCont (\_ -> Absent) Present h k 0 m
 {-# INLINABLE lookupRecordCollision #-}
 #endif
 
@@ -677,8 +679,10 @@ lookupCont ::
   => ((# #) -> r)    -- Absent continuation
   -> (v -> Int -> r) -- Present continuation
   -> Hash -- The hash of the key
-  -> k -> HashMap k v -> r
-lookupCont absent present !h0 !k0 !m0 = go h0 k0 0 m0
+  -> k
+  -> Int -- The subkey
+  -> HashMap k v -> r
+lookupCont absent present !h0 !k0 !s0 !m0 = go h0 k0 s0 m0
   where
     go :: Eq k => Hash -> k -> Int -> HashMap k v -> r
     go !_ !_ !_ Empty = absent (# #)
@@ -1409,6 +1413,112 @@ alterFEager f !k m = (<$> f mv) $ \fres ->
 {-# INLINABLE alterFEager #-}
 #endif
 
+-- | /O(n*m)/ Subset of maps. A map is a subset of another map if the keys are
+-- subsets and the corresponding values are equal:
+--
+-- >>> subset m1 m2 = keys m1 ⊆ keys m2 && and [ v1 == v2 | (k1,v1) <- toList m1; let v2 = m2 ! k1 ]
+--
+-- This defines a partial order on maps, for which 'union' is the least upper bound.
+-- More specifically, @subset m1 (union m1 m2)@ and @subset m2 (union m1 m2)@.
+--
+-- ==== __Examples__
+--
+-- >>> subset (fromList [(1,'a')]) (fromList [(1,'a'),(2,'b')])
+-- True
+--
+-- >>> subset (fromList [(1,'a'),(2,'b')]) (fromList [(1,'a')])
+-- False
+subset :: (Eq k, Hashable k, Eq v) => HashMap k v -> HashMap k v -> Bool
+subset = subsetWith (const (==))
+{-# INLINE subset #-}
+
+-- | /O(n*m)/ Subset of maps with value comparison. A map is a subset of another
+-- map if the keys are subsets and the corresponding values are smaller:
+--
+-- >>> subsetWith (⊑) m1 m2 = keys m1 ⊆ keys m2 && and [ v1 ⊑ v2 | (k1,v1) <- toList m1; let v2 = m2 ! k1 ]
+--
+-- This defines a partial order on maps, for which 'unionWith' is the least upper bound.
+-- More specifically, @subsetWith (⊑) m1 (unionWith (⊔) m1 m2)@ and @subset (⊑) m2 (unionWith (⊔) m1 m2)@.
+subsetWith :: (Eq k, Hashable k) => (k -> v1 -> v2 -> Bool) -> HashMap k v1 -> HashMap k v2 -> Bool
+subsetWith comp = go 0
+  where
+    -- An empty map is always a subset of any other map.
+    go !_ Empty _ = True
+
+    -- If the first map contains only one entry, lookup the key in the second map.
+    go s (Leaf h1 (L k1 v1)) t2 = lookupCont (\_ -> False) (\v2 _ -> comp k1 v1 v2) h1 k1 s t2
+
+    -- In this case we need to check that for each x in ls1, there is a y in ls2
+    -- such that x ⊑ y. This is the worst case complexity-wise since it requires a O(m*n) check.
+    go _ (Collision h1 ls1) (Collision h2 ls2) =
+      h1 == h2 && subsetArray comp ls1 ls2
+
+    -- To check ls1 ⊆ ls2, we only need to check the entries in ls2 with the hash h1.
+    go s t1@(Collision h1 _) (BitmapIndexed b ls2)
+        | b .&. m == 0 = False
+        | otherwise    =
+            go (s+bitsPerSubkey) t1 (A.index ls2 (sparseIndex b m))
+      where m = mask h1 s
+
+    -- Similar to the previous case we need to traverse l2 at the index for the hash h1.
+    go s t1@(Collision h1 _) (Full ls2) =
+      go (s+bitsPerSubkey) t1 (A.index ls2 (index h1 s))
+
+    -- Insert the collision into a bitmap indexed node and recurse.
+    go s t1@(BitmapIndexed {}) t2@(Collision h2 _) =
+      go s t1 (BitmapIndexed (mask h2 s) (A.singleton t2))
+    go s t1@(Full {}) t2@(Collision h2 _) =
+      go s t1 (BitmapIndexed (mask h2 s) (A.singleton t2))
+
+    -- In cases where the first and second map are bitmap indexed or full,
+    -- traverse down the tree at the appropriate indices.
+    go s (BitmapIndexed b1 ls1) (BitmapIndexed b2 ls2) =
+      subsetBitmapIndexed (go (s+bitsPerSubkey)) b1 ls1 b2 ls2
+    go s (BitmapIndexed b1 ls1) (Full ls2) =
+      subsetBitmapIndexed (go (s+bitsPerSubkey)) b1 ls1 fullNodeMask ls2
+    go s (Full ls1) (Full ls2) =
+      subsetBitmapIndexed (go (s+bitsPerSubkey)) fullNodeMask ls1 fullNodeMask ls2
+    go s (Full ls1) (BitmapIndexed b2 ls2) =
+      subsetBitmapIndexed (go (s+bitsPerSubkey)) fullNodeMask ls1 b2 ls2
+
+    -- TODO: I'm not sure about these cases and need help. If we cleared up all
+    -- these cases, we can replace them with a catch-all case go _ _ _ = False
+
+    -- If the second map is empty, but the first is not, it cannot be a subset.
+    go _ _ Empty = False
+
+    -- A collision always contains at least two entries. Hence it cannot be a
+    -- subset of a leaf.
+    go _ (Collision {}) (Leaf {}) = False
+
+    -- A bitmap indexed node and a full node always contain at least two
+    -- entries. Hence they cannot be a subset of a leaf.
+    go _ (BitmapIndexed {}) (Leaf {}) = False
+    go _ (Full {}) (Leaf {}) = False
+
+
+-- | /O(min n m))/ hecks if a bitmap indexed node is a subset of another.
+subsetBitmapIndexed :: (HashMap k v1 -> HashMap k v2 -> Bool) -> Bitmap -> A.Array (HashMap k v1) -> Bitmap -> A.Array (HashMap k v2) -> Bool
+subsetBitmapIndexed comp b1 ary1 b2 ary2 = subsetBitmaps && go 0 0 (b1Orb2 .&. negate b1Orb2)
+  where
+    go :: Int -> Int -> Bitmap -> Bool
+    go i j m
+      | m > b1Orb2 = True
+
+      -- In case a key is both in ary1 and ary2, check ary1[i] <= ary2[j] and
+      -- increment the indices i and j.
+      | b1Andb2 .&. m /= 0 = comp (A.index ary1 i) (A.index ary2 j) &&
+                             go (i+1) (j+1) (m `unsafeShiftL` 1)
+
+      -- In case a key occurs in ary1, but not ary2, only increment index j.
+      | b2 .&. m /= 0 = go i (j+1) (m `unsafeShiftL` 1)
+
+      -- In case a key neither occurs in ary1 nor ary2, continue.
+      | otherwise = go i j (m `unsafeShiftL` 1)
+
+    b1Andb2 = b1 .&. b2
+    b1Orb2  = b1 .|. b2
+    subsetBitmaps = b1Orb2 == b2
 
 ------------------------------------------------------------------------
 -- * Combine
@@ -2075,6 +2185,15 @@ updateOrConcatWithKey f ary1 ary2 = A.run $ do
     go n1 0
     return mary
 {-# INLINABLE updateOrConcatWithKey #-}
+
+-- | /O(n*m)/ Check if the first array is a subset of the second array.
+subsetArray :: Eq k => (k -> v1 -> v2 -> Bool) -> A.Array (Leaf k v1) -> A.Array (Leaf k v2) -> Bool
+subsetArray cmpV ary1 ary2 = A.length ary1 <= A.length ary2 && go 0 (A.length ary1)
+  where
+    go !i n
+      | i >= n = True
+      | otherwise = let (L k1 v1) = A.index ary1 i
+                    in lookupInArrayCont (\_ -> False) (\v2 _ -> cmpV k1 v1 v2 && go (i+1) n) k1 ary2
 
 ------------------------------------------------------------------------
 -- Manually unrolled loops

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1485,14 +1485,6 @@ isSubmapOfBy comp = go 0
     go s t1@(Collision h1 _) (Full ls2) =
       go (s+bitsPerSubkey) t1 (A.index ls2 (index h1 s))
 
-    -- Insert the collision into a bitmap indexed node and recurse.
-    go s t1@(BitmapIndexed {}) t2@(Collision h2 _) =
-      go s t1 (BitmapIndexed (mask h2 s) (A.singleton t2))
-    go s t1@(BitmapIndexed {}) t2@(Leaf h2 _) =
-      go s t1 (BitmapIndexed (mask h2 s) (A.singleton t2))
-    go s t1@(Full {}) t2@(Collision h2 _) =
-      go s t1 (BitmapIndexed (mask h2 s) (A.singleton t2))
-
     -- In cases where the first and second map are BitmapIndexed or Full,
     -- traverse down the tree at the appropriate indices.
     go s (BitmapIndexed b1 ls1) (BitmapIndexed b2 ls2) =
@@ -1501,14 +1493,15 @@ isSubmapOfBy comp = go 0
       submapBitmapIndexed (go (s+bitsPerSubkey)) b1 ls1 fullNodeMask ls2
     go s (Full ls1) (Full ls2) =
       submapBitmapIndexed (go (s+bitsPerSubkey)) fullNodeMask ls1 fullNodeMask ls2
-    go s (Full ls1) (BitmapIndexed b2 ls2) =
-      submapBitmapIndexed (go (s+bitsPerSubkey)) fullNodeMask ls1 b2 ls2
 
     -- Collision and Full nodes always contain at least two entries. Hence it
     -- cannot be a map of a leaf.
     go _ (Collision {}) (Leaf {}) = False
+    go _ (BitmapIndexed {}) (Leaf {}) = False
     go _ (Full {}) (Leaf {}) = False
-
+    go _ (BitmapIndexed {}) (Collision {}) = False
+    go _ (Full {}) (Collision {}) = False
+    go _ (Full {}) (BitmapIndexed {}) = False
 
 -- | /O(min n m))/ Checks if a bitmap indexed node is a submap of another.
 submapBitmapIndexed :: (HashMap k v1 -> HashMap k v2 -> Bool) -> Bitmap -> A.Array (HashMap k v1) -> Bitmap -> A.Array (HashMap k v2) -> Bool

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1435,7 +1435,8 @@ isSubmapOf = isSubmapOfBy (==)
 {-# INLINE isSubmapOf #-}
 
 -- | /O(n*log m)/ Inclusion of maps with value comparison. A map is included in
--- another map if the keys are subsets and the corresponding values are smaller:
+-- another map if the keys are subsets and if the comparison function is true
+-- for the corresponding values:
 --
 -- > isSubmapOfBy cmpV m1 m2 = keys m1 `isSubsetOf` keys m2 &&
 -- >                           and [ v1 `cmpV` v2 | (k1,v1) <- toList m1; let v2 = m2 ! k1 ]
@@ -1453,9 +1454,9 @@ isSubmapOfBy :: (Eq k, Hashable k) => (v1 -> v2 -> Bool) -> HashMap k v1 -> Hash
 -- For each leaf in m1, it looks up the key in m2.
 --
 -- The worst case complexity is O(n*m). The worst case is when both hashmaps m1
--- and m2 are collision nodes. Since collision nodes are unsorted arrays, it
--- requires for every key in m1 a linear search to to find a matching key in m2,
--- hence O(n*m).
+-- and m2 are collision nodes for the same hash. Since collision nodes are
+-- unsorted arrays, it requires for every key in m1 a linear search to to find a
+-- matching key in m2, hence O(n*m).
 isSubmapOfBy comp = go 0
   where
     -- An empty map is always a submap of any other map.

--- a/Data/HashMap/Internal/Array.hs
+++ b/Data/HashMap/Internal/Array.hs
@@ -59,6 +59,7 @@ module Data.HashMap.Internal.Array
     , foldr
     , foldr'
     , foldMap
+    , all
 
     , thaw
     , map
@@ -79,9 +80,9 @@ import GHC.ST (ST(..))
 import Control.Monad.ST (stToIO)
 
 #if __GLASGOW_HASKELL__ >= 709
-import Prelude hiding (filter, foldMap, foldr, foldl, length, map, read, traverse)
+import Prelude hiding (filter, foldMap, foldr, foldl, length, map, read, traverse, all)
 #else
-import Prelude hiding (filter, foldr, foldl, length, map, read)
+import Prelude hiding (filter, foldr, foldl, length, map, read, all)
 #endif
 
 #if __GLASGOW_HASKELL__ >= 710
@@ -460,6 +461,11 @@ foldMap f = \ary0 -> case length ary0 of
           if i == lst then fx else fx `mappend` go (i + 1)
     in go 0
 {-# INLINE foldMap #-}
+
+-- | Verifies that a predicate holds for all elements of an array.
+all :: (a -> Bool) -> Array a -> Bool
+all p = foldr (\a acc -> p a && acc) True
+{-# INLINE all #-}
 
 undefinedElem :: a
 undefinedElem = error "Data.HashMap.Internal.Array: Undefined element"

--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -63,6 +63,8 @@ module Data.HashMap.Internal.Strict
     , update
     , alter
     , alterF
+    , subset
+    , subsetWith
 
       -- * Combine
       -- ** Union

--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -63,8 +63,8 @@ module Data.HashMap.Internal.Strict
     , update
     , alter
     , alterF
-    , subset
-    , subsetWith
+    , isSubmapOf
+    , isSubmapOfBy
 
       -- * Combine
       -- ** Union

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -49,6 +49,8 @@ module Data.HashMap.Lazy
     , update
     , alter
     , alterF
+    , subset
+    , subsetWith
 
       -- * Combine
       -- ** Union

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -49,8 +49,8 @@ module Data.HashMap.Lazy
     , update
     , alter
     , alterF
-    , subset
-    , subsetWith
+    , isSubmapOf
+    , isSubmapOfBy
 
       -- * Combine
       -- ** Union

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -48,8 +48,8 @@ module Data.HashMap.Strict
     , update
     , alter
     , alterF
-    , subset
-    , subsetWith
+    , isSubmapOf
+    , isSubmapOfBy
 
       -- * Combine
       -- ** Union

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -48,6 +48,8 @@ module Data.HashMap.Strict
     , update
     , alter
     , alterF
+    , subset
+    , subsetWith
 
       -- * Combine
       -- ** Union

--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -111,6 +111,7 @@ module Data.HashSet
     , member
     , insert
     , delete
+    , subset
 
     -- * Transformations
     , map

--- a/Data/HashSet.hs
+++ b/Data/HashSet.hs
@@ -111,7 +111,7 @@ module Data.HashSet
     , member
     , insert
     , delete
-    , subset
+    , isSubsetOf
 
     -- * Transformations
     , map

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -55,6 +55,7 @@ module Data.HashSet.Internal
     , member
     , insert
     , delete
+    , subset
 
     -- * Transformations
     , map
@@ -309,6 +310,10 @@ fromMap = HashSet
 -- @since 0.2.10.0
 keysSet :: HashMap k a -> HashSet k
 keysSet m = fromMap (() <$ m)
+
+-- | /O(n*m)/ Subset of sets.
+subset :: (Eq a, Hashable a) => HashSet a -> HashSet a -> Bool
+subset s1 s2 = H.subsetWith (\_ _ _ -> True) (asMap s1) (asMap s2)
 
 -- | /O(n+m)/ Construct a set containing all elements from both sets.
 --

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -311,7 +311,7 @@ fromMap = HashSet
 keysSet :: HashMap k a -> HashSet k
 keysSet m = fromMap (() <$ m)
 
--- | /O(n*m)/ Inclusion of sets.
+-- | /O(n*log m)/ Inclusion of sets.
 --
 -- ==== __Examples__
 --

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -55,7 +55,7 @@ module Data.HashSet.Internal
     , member
     , insert
     , delete
-    , subset
+    , isSubsetOf
 
     -- * Transformations
     , map
@@ -311,9 +311,9 @@ fromMap = HashSet
 keysSet :: HashMap k a -> HashSet k
 keysSet m = fromMap (() <$ m)
 
--- | /O(n*m)/ Subset of sets.
-subset :: (Eq a, Hashable a) => HashSet a -> HashSet a -> Bool
-subset s1 s2 = H.subsetWith (\_ _ _ -> True) (asMap s1) (asMap s2)
+-- | /O(n*m)/ Inclusion of sets.
+isSubsetOf :: (Eq a, Hashable a) => HashSet a -> HashSet a -> Bool
+isSubsetOf s1 s2 = H.isSubmapOfBy (\_ _ -> True) (asMap s1) (asMap s2)
 
 -- | /O(n+m)/ Construct a set containing all elements from both sets.
 --

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -312,6 +312,14 @@ keysSet :: HashMap k a -> HashSet k
 keysSet m = fromMap (() <$ m)
 
 -- | /O(n*m)/ Inclusion of sets.
+--
+-- ==== __Examples__
+--
+-- >>> fromList [1,3] `isSubsetOf` fromList [1,2,3]
+-- True
+--
+-- >>> fromList [1,2] `isSubsetOf` fromList [1,3]
+-- False
 isSubsetOf :: (Eq a, Hashable a) => HashSet a -> HashSet a -> Bool
 isSubsetOf s1 s2 = H.isSubmapOfBy (\_ _ -> True) (asMap s1) (asMap s2)
 

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -305,9 +305,9 @@ main = do
             , bench "Int" $ whnf (HM.isSubmapOf hmiSubset) hmi
             ]
           , bgroup "isSubmapOfNaive"
-            [ bench "String" $ whnf (HM.isSubmapOf hmSubset) hm
-            , bench "ByteString" $ whnf (HM.isSubmapOf hmbsSubset) hmbs
-            , bench "Int" $ whnf (HM.isSubmapOf hmiSubset) hmi
+            [ bench "String" $ whnf (isSubmapOfNaive hmSubset) hm
+            , bench "ByteString" $ whnf (isSubmapOfNaive hmbsSubset) hmbs
+            , bench "Int" $ whnf (isSubmapOfNaive hmiSubset) hmi
             ]
 
             -- Combine

--- a/tests/HashMapProperties.hs
+++ b/tests/HashMapProperties.hs
@@ -225,44 +225,44 @@ pAlterFLookup k f =
   `eq`
   getConst . HM.alterF (Const . apply f) k
 
-pSubsetReflexive :: [(Key, Int)] -> Bool
-pSubsetReflexive xs =
+pSubmapReflexive :: [(Key, Int)] -> Bool
+pSubmapReflexive xs =
   let m = HM.fromList xs
-  in HM.subset m m
+  in HM.isSubmapOf m m
 
-pSubsetUnion :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pSubsetUnion xs ys =
+pSubmapUnion :: [(Key, Int)] -> [(Key, Int)] -> Bool
+pSubmapUnion xs ys =
   let m1 = HM.fromList xs
       m2 = HM.fromList ys
-  in HM.subset m1 (HM.union m1 m2)
+  in HM.isSubmapOf m1 (HM.union m1 m2)
 
-pNotSubsetUnion :: [(Key, Int)] -> [(Key, Int)] -> Bool
-pNotSubsetUnion xs ys =
+pNotSubmapUnion :: [(Key, Int)] -> [(Key, Int)] -> Bool
+pNotSubmapUnion xs ys =
   let m1 = HM.fromList xs
       m2 = HM.fromList ys
-  in not (HM.subset m1 m2) ⇒ HM.subset m1 (HM.union m1 m2)
+  in not (HM.isSubmapOf m1 m2) ⇒ HM.isSubmapOf m1 (HM.union m1 m2)
 
-pSubsetDelete :: [(Key,Int)] -> Bool
-pSubsetDelete xs@((k,_):_) =
+pSubmapDelete :: [(Key,Int)] -> Bool
+pSubmapDelete xs@((k,_):_) =
   let m = HM.fromList xs
-  in HM.subset (HM.delete k m) m
-pSubsetDelete [] = True
+  in HM.isSubmapOf (HM.delete k m) m
+pSubmapDelete [] = True
 
-pNotSubsetDelete :: [(Key,Int)] -> Bool
-pNotSubsetDelete xs@((k,_):_) =
+pNotSubmapDelete :: [(Key,Int)] -> Bool
+pNotSubmapDelete xs@((k,_):_) =
   let m = HM.fromList xs
-  in not (HM.subset m (HM.delete k m))
-pNotSubsetDelete [] = True
+  in not (HM.isSubmapOf m (HM.delete k m))
+pNotSubmapDelete [] = True
 
-pSubsetInsert :: Key -> Int -> [(Key,Int)] -> Bool
-pSubsetInsert k v xs =
+pSubmapInsert :: Key -> Int -> [(Key,Int)] -> Bool
+pSubmapInsert k v xs =
   let m = HM.fromList xs
-  in not (HM.member k m) ⇒ HM.subset m (HM.insert k v m)
+  in not (HM.member k m) ⇒ HM.isSubmapOf m (HM.insert k v m)
 
-pNotSubsetInsert :: Key -> Int -> [(Key,Int)] -> Bool
-pNotSubsetInsert k v xs =
+pNotSubmapInsert :: Key -> Int -> [(Key,Int)] -> Bool
+pNotSubmapInsert k v xs =
   let m = HM.fromList xs
-  in not (HM.member k m) ⇒ not (HM.subset (HM.insert k v m) m)
+  in not (HM.member k m) ⇒ not (HM.isSubmapOf (HM.insert k v m) m)
 
 ------------------------------------------------------------------------
 -- ** Combine
@@ -478,14 +478,14 @@ tests =
       , testProperty "alterFInsertWith" pAlterFInsertWith
       , testProperty "alterFDelete" pAlterFDelete
       , testProperty "alterFLookup" pAlterFLookup
-      , testGroup "subset"
-        [ testProperty "m ⊆ m" pSubsetReflexive
-        , testProperty "m1 ⊆ m1 ∪ m2" pSubsetUnion
-        , testProperty "m1 ⊈ m2  ⇒  m1 ∪ m2 ⊈ m1" pNotSubsetUnion
-        , testProperty "delete k m ⊆ m" pSubsetDelete
-        , testProperty "m ⊈ delete k m " pNotSubsetDelete
-        , testProperty "k ∉ m  ⇒  m ⊆ insert k v m" pSubsetInsert
-        , testProperty "k ∉ m  ⇒  insert k v m ⊈ m" pNotSubsetInsert
+      , testGroup "isSubmapOf"
+        [ testProperty "m ⊆ m" pSubmapReflexive
+        , testProperty "m1 ⊆ m1 ∪ m2" pSubmapUnion
+        , testProperty "m1 ⊈ m2  ⇒  m1 ∪ m2 ⊈ m1" pNotSubmapUnion
+        , testProperty "delete k m ⊆ m" pSubmapDelete
+        , testProperty "m ⊈ delete k m " pNotSubmapDelete
+        , testProperty "k ∉ m  ⇒  m ⊆ insert k v m" pSubmapInsert
+        , testProperty "k ∉ m  ⇒  insert k v m ⊈ m" pNotSubmapInsert
         ]
       ]
     -- Combine

--- a/tests/HashMapProperties.hs
+++ b/tests/HashMapProperties.hs
@@ -269,10 +269,6 @@ pSubmapInsert k v m = not (HM.member k m) ==> HM.isSubmapOf m (HM.insert k v m)
 pNotSubmapInsert :: Key -> Int -> HashMap Key Int -> Property
 pNotSubmapInsert k v m = not (HM.member k m) ==> not (HM.isSubmapOf (HM.insert k v m) m)
 
-pSubmapInsertDelete :: Key -> Int -> HashMap Key Int -> Property
-pSubmapInsertDelete k v m =
-  not (HM.member k m) ==> HM.isSubmapOf (HM.delete k (HM.insert k v m)) m
-
 ------------------------------------------------------------------------
 -- ** Combine
 

--- a/tests/HashMapProperties.hs
+++ b/tests/HashMapProperties.hs
@@ -245,6 +245,10 @@ pNotSubmapUnion xs ys =
 pSubmapDelete :: [(Key,Int)] -> Bool
 pSubmapDelete xs@((k,_):_) =
   let m = HM.fromList xs
+pSubmap :: [(Key, Int)] -> [(Key, Int)] -> Bool
+pSubmap xs ys = M.isSubmapOf (M.fromList xs) (M.fromList ys) ==
+                HM.isSubmapOf (HM.fromList xs) (HM.fromList ys)
+
   in HM.isSubmapOf (HM.delete k m) m
 pSubmapDelete [] = True
 
@@ -479,7 +483,8 @@ tests =
       , testProperty "alterFDelete" pAlterFDelete
       , testProperty "alterFLookup" pAlterFLookup
       , testGroup "isSubmapOf"
-        [ testProperty "m ⊆ m" pSubmapReflexive
+        [ testProperty "container compatibility" pSubmap
+        , testProperty "m ⊆ m" pSubmapReflexive
         , testProperty "m1 ⊆ m1 ∪ m2" pSubmapUnion
         , testProperty "m1 ⊈ m2  ⇒  m1 ∪ m2 ⊈ m1" pNotSubmapUnion
         , testProperty "delete k m ⊆ m" pSubmapDelete


### PR DESCRIPTION
Dear Johan, Dear David,

First of all, thanks for putting all this hard work into this library. We use it heavily in [Sturdy](https://github.com/svenkeidel/sturdy) to implement static code analyses in Haskell. To this end, we need a fast subset operation on hashmaps and hashsets. Unfortunately, while a naive implementation is easy to understand, it is rather slow because it compares keys with different hashes:
```Haskell
subset :: (Eq k, Hashable k, Eq v) => HashMap k v -> HashMap k v -> Bool
subset m1 m2 = keys m1 ⊆ keys m2 && and [ v1 == v2 | (k1,v1) <- toList m1; let v2 = m2 ! k1 ]
```

Instead, I worked on an [implementation](https://github.com/haskell-unordered-containers/unordered-containers/compare/master...svenkeidel:subset2?expand=1#diff-11321ff356efb0247b49763554dc8620R1431) that only compares keys with the same hash. I had to extend the `lookupCont` function with the number of the subkey to avoid code duplication. I tested this implementation with a few QuickCheck [properties](https://github.com/haskell-unordered-containers/unordered-containers/compare/master...svenkeidel:subset2?expand=1#diff-3d7e2d423eb3691821ef78fb73b2fa75R481-R489). What do you think?

I would be delighted if you would add this function to the library.

Regards,
Sven