### PR TITLE
alterF: Skip deleting the key when it's already absent

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1282,7 +1282,7 @@ alterF f = \ !k !m ->
     mv = lookup' h k m
   in (<$> f mv) $ \fres ->
     case fres of
-      Nothing -> delete' h k m
+      Nothing -> maybe m (const (delete' h k m)) mv
       Just v' -> insert' h k v' m
 
 -- We unconditionally rewrite alterF in RULES, but we expose an

--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -314,7 +314,7 @@ alterF f = \ !k !m ->
       mv = lookup' h k m
   in (<$> f mv) $ \fres ->
     case fres of
-      Nothing -> delete' h k m
+      Nothing -> maybe m (const (delete' h k m)) mv
       Just !v' -> insert' h k v' m
 
 -- We rewrite this function unconditionally in RULES, but we expose


### PR DESCRIPTION
Fixes #287.