### PR TITLE
Mark internal modules `not-home` for haddock

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE UnboxedSums #-}
 #endif
 {-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 -- | = WARNING
 --

--- a/Data/HashMap/Internal/Array.hs
+++ b/Data/HashMap/Internal/Array.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns, CPP, MagicHash, Rank2Types, UnboxedTuples, ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 -- | = WARNING
 --

--- a/Data/HashMap/Internal/List.hs
+++ b/Data/HashMap/Internal/List.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-full-laziness -funbox-strict-fields #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 -- | = WARNING
 --

--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns, CPP, PatternGuards, MagicHash, UnboxedTuples #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE Trustworthy #-}
+{-# OPTIONS_HADDOCK not-home #-}
 
 ------------------------------------------------------------------------
 -- |

--- a/Data/HashMap/Internal/Unsafe.hs
+++ b/Data/HashMap/Internal/Unsafe.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE MagicHash, Rank2Types, UnboxedTuples #-}
 #endif
 
+{-# OPTIONS_HADDOCK not-home #-}
+
 -- | = WARNING
 --
 -- This module is considered __internal__.

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -6,6 +6,7 @@
 #if __GLASGOW_HASKELL__ >= 702
 {-# LANGUAGE Trustworthy #-}
 #endif
+{-# OPTIONS_HADDOCK not-home #-}
 
 ------------------------------------------------------------------------
 -- |


### PR DESCRIPTION
…to ensure that hyperlinks preferably target the public modules.