### PR TITLE
Fix 'compose' since tag

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1699,7 +1699,7 @@ unions = L.foldl' union empty
 -- ('compose' bc ab '!?') = (bc '!?') <=< (ab '!?')
 -- @
 --
--- @since UNRELEASED
+-- @since 0.2.13.0
 compose :: (Eq b, Hashable b) => HashMap b c -> HashMap a b -> HashMap a c
 compose bc !ab
   | null bc = empty


### PR DESCRIPTION
On [Hackage](https://hackage.haskell.org/package/unordered-containers-0.2.13.0/docs/Data-HashMap-Strict.html#g:6) there is an ugly `@since UNRELEASED` in the documentation for compose. I guess #299 didn't fix the tag when it got merged.