### PR TITLE
add mapKeys

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -67,6 +67,7 @@ module Data.HashMap.Internal
     , map
     , mapWithKey
     , traverseWithKey
+    , mapKeys
 
       -- * Difference and intersection
     , difference
@@ -1750,6 +1751,18 @@ traverseWithKey f = go
     go (Collision h ary)     =
         Collision h <$> A.traverse' (\ (L k v) -> L k <$> f k v) ary
 {-# INLINE traverseWithKey #-}
+
+-- | /O(n)/.
+-- @'mapKeys' f s@ is the map obtained by applying @f@ to each key of @s@.
+--
+-- The size of the result may be smaller if @f@ maps two or more distinct
+-- keys to the same new key.  In this case the later mappings take precedence.
+--
+-- > mapKeys (+ 1) (fromList [(5,"a"), (3,"b")])                        == fromList [(4, "b"), (6, "a")]
+-- > mapKeys (\ _ -> 1) (fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")]) == singleton 1 "c"
+-- > mapKeys (\ _ -> 3) (fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")]) == singleton 3 "c"
+mapKeys :: (Eq k2, Hashable k2) => (k1 -> k2) -> HashMap k1 v -> HashMap k2 v
+mapKeys f = fromList . foldrWithKey (\k x xs -> (f k, x) : xs) []
 
 ------------------------------------------------------------------------
 -- * Difference and intersection

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1756,8 +1756,8 @@ traverseWithKey f = go
 -- @'mapKeys' f s@ is the map obtained by applying @f@ to each key of @s@.
 --
 -- The size of the result may be smaller if @f@ maps two or more distinct
--- keys to the same new key. In this case the value chosen for the conflicting
--- key could be unexpected as it depends on the library internals.
+-- keys to the same new key. In this case there is no guarantee which of the
+-- associated values is chosen for the conflicting key.
 --
 -- >>> mapKeys (+ 1) (fromList [(5,"a"), (3,"b")])
 -- fromList [(4,"b"),(6,"a")]

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1758,9 +1758,12 @@ traverseWithKey f = go
 -- The size of the result may be smaller if @f@ maps two or more distinct
 -- keys to the same new key.  In this case the later mappings take precedence.
 --
--- > mapKeys (+ 1) (fromList [(5,"a"), (3,"b")])                        == fromList [(4, "b"), (6, "a")]
--- > mapKeys (\ _ -> 1) (fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")]) == singleton 1 "c"
--- > mapKeys (\ _ -> 3) (fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")]) == singleton 3 "c"
+-- >>> mapKeys (+ 1) (fromList [(5,"a"), (3,"b")])
+-- fromList [(4,"b"),(6,"a")]
+-- >>> mapKeys (\ _ -> 1) (fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")])
+-- fromList [(1,"c")]
+-- >>> mapKeys (\ _ -> 3) (fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")])
+-- fromList [(3,"c")]
 mapKeys :: (Eq k2, Hashable k2) => (k1 -> k2) -> HashMap k1 v -> HashMap k2 v
 mapKeys f = fromList . foldrWithKey (\k x xs -> (f k, x) : xs) []
 

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1756,7 +1756,8 @@ traverseWithKey f = go
 -- @'mapKeys' f s@ is the map obtained by applying @f@ to each key of @s@.
 --
 -- The size of the result may be smaller if @f@ maps two or more distinct
--- keys to the same new key.  In this case the later mappings take precedence.
+-- keys to the same new key. In this case the value chosen for the conflicting
+-- key could be unexpected as it depends on the library internals.
 --
 -- >>> mapKeys (+ 1) (fromList [(5,"a"), (3,"b")])
 -- fromList [(4,"b"),(6,"a")]

--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -81,6 +81,7 @@ module Data.HashMap.Internal.Strict
     , map
     , mapWithKey
     , traverseWithKey
+    , mapKeys
 
       -- * Difference and intersection
     , difference

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -66,6 +66,7 @@ module Data.HashMap.Lazy
     , map
     , mapWithKey
     , traverseWithKey
+    , mapKeys
 
       -- * Difference and intersection
     , difference

--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -65,6 +65,7 @@ module Data.HashMap.Strict
     , map
     , mapWithKey
     , traverseWithKey
+    , mapKeys
 
       -- * Difference and intersection
     , difference

--- a/tests/HashMapProperties.hs
+++ b/tests/HashMapProperties.hs
@@ -301,6 +301,9 @@ pTraverse xs =
   L.sort (fmap (L.sort . M.toList) (M.traverseWithKey (\_ v -> [v + 1, v + 2]) (M.fromList (take 10 xs))))
      == L.sort (fmap (L.sort . HM.toList) (HM.traverseWithKey (\_ v -> [v + 1, v + 2]) (HM.fromList (take 10 xs))))
 
+pMapKeys :: [(Int, Int)] -> Bool
+pMapKeys = M.mapKeys (+1) `eq_` HM.mapKeys (+1)
+
 ------------------------------------------------------------------------
 -- ** Difference and intersection
 
@@ -504,6 +507,7 @@ tests =
     -- Transformations
     , testProperty "map" pMap
     , testProperty "traverse" pTraverse
+    , testProperty "mapKeys" pMapKeys
     -- Folds
     , testGroup "folds"
       [ testProperty "foldr" pFoldr


### PR DESCRIPTION
this PR adds `mapKeys` to the API, following the implementation provided by `containers`.

I'm not an expert in performances and on the internals of `unordered-containers`, so feel free to refuse this if it is not up to the standards of the library