### PR TITLE
32bit base

### DIFF
--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -195,7 +195,7 @@ insertWith f k0 v0 m0 = go h0 k0 v0 0 m0
     go h k x s (Full ary) =
         let st   = A.index ary i
             st'  = go h k x (s+bitsPerSubkey) st
-            ary' = update16 ary i $! st'
+            ary' = update32 ary i $! st'
         in Full ary'
       where i = index h s
     go h k x s t@(Collision hy v)
@@ -266,7 +266,7 @@ adjust f k0 m0 = go h0 k0 0 m0
         let i    = index h s
             st   = A.index ary i
             st'  = go h k (s+bitsPerSubkey) st
-            ary' = update16 ary i $! st'
+            ary' = update32 ary i $! st'
         in Full ary'
     go h k _ t@(Collision hy v)
         | h == hy   = Collision h (updateWith f k v)
@@ -494,12 +494,12 @@ unionWithKey f = go 0
     go s (Full ary1) t2 =
         let h2   = leafHashCode t2
             i    = index h2 s
-            ary' = update16With' ary1 i $ \st1 -> go (s+bitsPerSubkey) st1 t2
+            ary' = update32With' ary1 i $ \st1 -> go (s+bitsPerSubkey) st1 t2
         in Full ary'
     go s t1 (Full ary2) =
         let h1   = leafHashCode t1
             i    = index h1 s
-            ary' = update16With' ary2 i $ \st2 -> go (s+bitsPerSubkey) t1 st2
+            ary' = update32With' ary2 i $ \st2 -> go (s+bitsPerSubkey) t1 st2
         in Full ary'
 
     leafHashCode (Leaf h _) = h

--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -35,7 +35,7 @@
 -- strings.
 --
 -- Many operations have a average-case complexity of /O(log n)/.  The
--- implementation uses a large base (i.e. 16) so in practice these
+-- implementation uses a large base (i.e. 32) so in practice these
 -- operations are constant time.
 module Data.HashMap.Internal.Strict
     (

--- a/Data/HashMap/Lazy.hs
+++ b/Data/HashMap/Lazy.hs
@@ -20,7 +20,7 @@
 -- strings.
 --
 -- Many operations have a average-case complexity of /O(log n)/.  The
--- implementation uses a large base (i.e. 16) so in practice these
+-- implementation uses a large base (i.e. 32) so in practice these
 -- operations are constant time.
 module Data.HashMap.Lazy
     (

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -35,7 +35,7 @@
 -- strings.
 --
 -- Many operations have a average-case complexity of /O(log n)/.  The
--- implementation uses a large base (i.e. 16) so in practice these
+-- implementation uses a large base (i.e. 32) so in practice these
 -- operations are constant time.
 
 module Data.HashSet.Internal

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -72,7 +72,7 @@ data Env = Env {
 
 setupEnv :: IO Env
 setupEnv = do
-    let n = 2^(12 :: Int)
+    let n = 4 * 2^(16 :: Int)
 
         elems   = zip keys [1..n]
         keys    = US.rnd 8 n

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -72,7 +72,7 @@ data Env = Env {
 
 setupEnv :: IO Env
 setupEnv = do
-    let n = 4 * 2^(16 :: Int)
+    let n = 2^(12 :: Int)
 
         elems   = zip keys [1..n]
         keys    = US.rnd 8 n


### PR DESCRIPTION
This PR does two things:
1. Swap the 16 bit base for a 32 bit base
2. Reorder many pattern matches to hit hot code paths with less comparisons

Regarding 1. this _should_ improve performance since a path in the tree become `log_32` rather than `log_16`. Similarly it should mean that the HAMT stays more shallow for longer. 

Note that the benchmark suite will not show the difference since `n = 2^12 = 4096` which means the HAMT doesn't get very nested. 

I've benchmarked the PR with `n = 4 * (2^16)` elements. This number is significant because with a 16 bit base then tree should increase in level after 2^16 elements are inserted (I believe). So this number of elements stress tests the HAMT and thus a difference between implementations is more noticeable. Here is a table of the comparison:

```
   Name                                master    branch Difference PctDifference
   <chr>                                <dbl>     <dbl>      <dbl>         <dbl>
 1 HashMap/insert/String            2.0030e-1 2.6837e-1  6.8074e-2      33.987  
 2 HashMap/alterFInsert/String      2.1753e-1 2.7419e-1  5.6655e-2      26.045  
 3 HashMap/isSubmapOf/ByteString    1.1734e-2 1.4180e-2  2.4460e-3      20.845  
 4 HashMap/lookup-miss/String       3.4322e-2 4.0775e-2  6.4534e-3      18.803  
 5 HashMap/fromList/short/Int       4.9360e-2 5.6371e-2  7.0111e-3      14.204  
 6 HashMap/alterDelete-miss/Str…    3.9093e-2 4.4139e-2  5.0463e-3      12.909  
 7 HashMap/alterInsert/Int          1.6629e-1 1.8363e-1  1.7341e-2      10.428  
 8 HashMap/fromListWith/short/I…    5.6768e-2 6.2198e-2  5.4307e-3       9.5665 
 9 HashMap/insert/ByteString        1.9137e-1 2.0795e-1  1.6575e-2       8.6611 
10 HashMap/alterFInsert/Int         1.6701e-1 1.7653e-1  9.5194e-3       5.6998 
11 HashMap/alterInsert/ByteStri…    2.1202e-1 2.2374e-1  1.1721e-2       5.5284 
12 HashMap/alterFInsert/ByteStr…    1.9252e-1 2.0284e-1  1.0322e-2       5.3617 
13 HashMap/insert/Int               1.6066e-1 1.6753e-1  6.8664e-3       4.2739 
14 HashMap/lookup/String            1.8751e-1 1.9298e-1  5.4667e-3       2.9154 
15 HashMap/alterFDelete/Int         1.2597e-1 1.2557e-1 -3.9674e-4      -0.31494
16 HashMap/delete/ByteString        1.9134e-1 1.8940e-1 -1.9429e-3      -1.0154 
17 HashMap/isSubmapOfNaive/Byte…    1.8026e-2 1.7503e-2 -5.2318e-4      -2.9024 
18 HashMap/delete/Int               1.3296e-1 1.2747e-1 -5.4821e-3      -4.1233 
19 HashMap/alterFInsert-dup/Int     1.3616e-1 1.3029e-1 -5.8736e-3      -4.3138 
20 HashMap/alterFDelete/ByteStr…    1.9870e-1 1.8918e-1 -9.5198e-3      -4.7910 
21 HashMap/alterFInsert-dup/Str…    1.0951e-1 1.0404e-1 -5.4631e-3      -4.9889 
22 HashMap/alterDelete/ByteStri…    2.0143e-1 1.9126e-1 -1.0166e-2      -5.0472 
23 HashMap/insert-dup/String        1.0905e-1 1.0261e-1 -6.4429e-3      -5.9079 
24 HashMap/map                      1.7489e-2 1.6364e-2 -1.1255e-3      -6.4352 
25 HashMap/alterDelete/Int          1.4028e-1 1.3015e-1 -1.0133e-2      -7.2233 
26 HashMap/difference               2.9006e-2 2.6571e-2 -2.4352e-3      -8.3956 
27 HashMap/fromList/long/String     1.2460e-1 1.1381e-1 -1.0790e-2      -8.6593 
28 HashMap/alterInsert/String       2.3628e-1 2.1523e-1 -2.1044e-2      -8.9067 
29 HashMap/lookup/ByteString        9.0018e-2 8.1684e-2 -8.3336e-3      -9.2577 
30 HashMap/alterInsert-dup/Int      1.3935e-1 1.2553e-1 -1.3822e-2      -9.9193 
31 HashMap/fromList/long/Int        7.9622e-2 7.1558e-2 -8.0643e-3     -10.128  
32 HashMap/insert-dup/Int           1.3674e-1 1.2280e-1 -1.3940e-2     -10.194  
33 HashMap/alterFDelete-miss/Int    7.3169e-2 6.4553e-2 -8.6158e-3     -11.775  
34 HashMap/fromListWith/short/S…    2.6485e-2 2.3176e-2 -3.3088e-3     -12.493  
35 HashMap/fromListWith/long/By…    9.8163e-2 8.5733e-2 -1.2430e-2     -12.663  
36 HashMap/alterDelete-miss/Int     7.8475e-2 6.8417e-2 -1.0058e-2     -12.817  
37 HashMap/intersection             2.9143e-2 2.5119e-2 -4.0241e-3     -13.808  
38 HashMap/fromListWith/long/Int    8.8757e-2 7.6069e-2 -1.2688e-2     -14.295  
39 HashMap/size/ByteString          3.6860e-3 3.0649e-3 -6.2114e-4     -16.851  
40 HashMap/lookup/Int               5.8667e-2 4.8705e-2 -9.9625e-3     -16.981  
41 HashMap/delete-miss/Int          7.1066e-2 5.8884e-2 -1.2182e-2     -17.141  
42 HashMap/size/String              3.1747e-3 2.5993e-3 -5.7544e-4     -18.126  
43 HashMap/fromList/short/ByteS…    2.3714e-2 1.9378e-2 -4.3362e-3     -18.285  
44 HashMap/filterWithKey            6.7425e-3 5.4882e-3 -1.2543e-3     -18.603  
45 HashMap/alterInsert-dup/Byte…    9.9778e-2 8.1030e-2 -1.8747e-2     -18.789  
46 HashMap/fromListWith/short/B…    2.2141e-2 1.7960e-2 -4.1809e-3     -18.883  
47 HashMap/foldl'                   3.8933e-3 3.1439e-3 -7.4942e-4     -19.249  
48 HashMap/filter                   1.3389e-2 1.0733e-2 -2.6563e-3     -19.839  
49 HashMap/fromList/long/ByteSt…    1.1492e-1 9.1809e-2 -2.3114e-2     -20.112  
50 HashMap/fromListWith/long/St…    1.2993e-1 1.0327e-1 -2.6664e-2     -20.521  
51 HashMap/insert-dup/ByteString    9.4205e-2 7.4592e-2 -1.9613e-2     -20.820  
52 HashMap/alterFInsert-dup/Byt…    9.4634e-2 7.4397e-2 -2.0237e-2     -21.384  
53 HashMap/lookup-miss/Int          3.3997e-2 2.6709e-2 -7.2885e-3     -21.438  
54 HashMap/union                    1.1522e-2 9.0485e-3 -2.4736e-3     -21.468  
55 HashMap/size/Int                 1.1961e-3 9.2380e-4 -2.7234e-4     -22.768  
56 HashMap/delete-miss/String       3.4340e-2 2.6487e-2 -7.8529e-3     -22.868  
57 HashMap/alterFDelete-miss/St…    3.4657e-2 2.6152e-2 -8.5043e-3     -24.539  
58 HashMap/alterFDelete-miss/By…    2.6543e-2 1.9803e-2 -6.7402e-3     -25.393  
59 HashMap/fromList/short/String    3.9645e-2 2.9554e-2 -1.0091e-2     -25.454  
60 HashMap/alterDelete-miss/Byt…    2.8437e-2 2.1007e-2 -7.4294e-3     -26.126  
61 HashMap/delete-miss/ByteStri…    2.7414e-2 1.9998e-2 -7.4164e-3     -27.053  
62 HashMap/lookup-miss/ByteStri…    2.4133e-2 1.7398e-2 -6.7349e-3     -27.907  
63 HashMap/alterFDelete/String      2.9774e-1 2.1209e-1 -8.5647e-2     -28.765  
64 HashMap/delete/String            2.9461e-1 2.0885e-1 -8.5761e-2     -29.110  
65 HashMap/alterDelete/String       3.0336e-1 2.1491e-1 -8.8451e-2     -29.157  
66 HashMap/alterInsert-dup/Stri…    1.9579e-1 1.0271e-1 -9.3082e-2     -47.541  
67 HashMap/foldr                    4.7994e-3 2.1380e-3 -2.6615e-3     -55.454  
68 HashMap/isSubmapOfNaive/Stri…    5.4429e-2 2.0382e-2 -3.4047e-2     -62.552  
69 HashMap/isSubmapOf/Int           3.3608e-7 1.2071e-7 -2.1537e-7     -64.084  
70 HashMap/isSubmapOf/String        5.2910e-2 1.7840e-2 -3.5070e-2     -66.283  
71 HashMap/isSubmapOfNaive/Int      1.6283e-7 3.8168e-8 -1.2467e-7     -76.560  
```

Positive numbers are slowdowns and negative numbers are speed ups. I'm unsure why some of the larger slowdowns occur and am hoping you might have some insight here. In any case I think the speedups are worth investing time, for example `HashMap/foldr` is 55% faster and `HashMap/lookup/Int` is 16% faster by these benchmarks!