### PR TITLE
Migrate benchmarks to tasty-bench

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -121,7 +121,7 @@ jobs:
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER < 90200)) -ne 0 ] ; then echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV" ; else echo "ARG_BENCH=--disable-benchmarks" >> "$GITHUB_ENV" ; fi
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -3,7 +3,6 @@
 module Main where
 
 import Control.DeepSeq
-import Gauge (bench, bgroup, defaultMain, env, nf, whnf)
 import Data.Bits ((.&.))
 import Data.Functor.Identity
 import Data.Hashable (Hashable, hash)
@@ -16,6 +15,7 @@ import Data.List (foldl')
 import Data.Maybe (fromMaybe)
 import GHC.Generics (Generic)
 import Prelude hiding (lookup)
+import Test.Tasty.Bench (bench, bgroup, defaultMain, env, nf, whnf)
 
 import qualified Util.ByteString as UBS
 import qualified Util.Int as UI

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,9 +2,6 @@
 
 branches: master
 
--- Due to https://github.com/haskell-foundation/foundation/issues/554 via gauge.
-benchmarks: <9.2
-
 constraint-set debug
   constraints: unordered-containers +debug
   tests:       True

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -202,16 +202,18 @@ benchmark benchmarks
     base >= 4.8.0,
     bytestring >= 0.10.0.0,
     containers,
-    gauge >= 0.2.5 && < 0.3,
     deepseq >= 1.4,
     hashable >= 1.0.1.1,
     hashmap,
     mtl,
     random,
+    tasty-bench >= 0.3.1,
     unordered-containers
 
   default-language: Haskell2010
-  ghc-options: -Wall -O2 -rtsopts -fwarn-tabs -ferror-spans
+  ghc-options: -Wall -O2 -rtsopts -with-rtsopts=-A32m
+  if impl(ghc >= 8.10)
+    ghc-options: "-with-rtsopts=-A32m --nonmoving-gc"
 
 source-repository head
   type:     git


### PR DESCRIPTION
tasty-bench is more actively maintained and supported.
gauge doesn't build with GHC 9.2 yet.