### PR TITLE
Add definitions for `stimes`

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -146,7 +146,6 @@ import qualified Data.Foldable as Foldable
 import Data.Bifoldable
 #endif
 import qualified Data.List as L
-import qualified Data.List.NonEmpty as NonEmpty
 import GHC.Exts ((==#), build, reallyUnsafePtrEquality#, inline)
 import Prelude hiding (filter, foldl, foldr, lookup, map, null, pred)
 import Text.Read hiding (step)
@@ -279,8 +278,6 @@ instance Bifoldable HashMap where
 instance (Eq k, Hashable k) => Semigroup (HashMap k v) where
   (<>) = union
   {-# INLINE (<>) #-}
-  sconcat = mconcat . NonEmpty.toList
-  {-# INLINE sconcat #-}
   stimes = stimesIdempotentMonoid
   {-# INLINE stimes #-}
 
@@ -299,8 +296,6 @@ instance (Eq k, Hashable k) => Monoid (HashMap k v) where
   {-# INLINE mempty #-}
   mappend = (<>)
   {-# INLINE mappend #-}
-  mconcat = unions
-  {-# INLINE mconcat #-}
 
 instance (Data k, Data v, Eq k, Hashable k) => Data (HashMap k v) where
     gfoldl f z m   = z fromList `f` toList m

--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns, CPP, PatternGuards, MagicHash, UnboxedTuples #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE Trustworthy #-}
 {-# OPTIONS_HADDOCK not-home #-}
 

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -102,7 +102,6 @@ import Prelude hiding (filter, foldr, foldl, map, null)
 import qualified Data.Foldable as Foldable
 import qualified Data.HashMap.Internal as H
 import qualified Data.List as List
-import qualified Data.List.NonEmpty as NonEmpty
 import Data.Typeable (Typeable)
 import Text.Read
 
@@ -194,8 +193,6 @@ instance Foldable.Foldable HashSet where
 instance (Hashable a, Eq a) => Semigroup (HashSet a) where
     (<>) = union
     {-# INLINE (<>) #-}
-    sconcat = mconcat . NonEmpty.toList
-    {-# INLINE sconcat #-}
     stimes = stimesIdempotentMonoid
     {-# INLINE stimes #-}
 
@@ -217,8 +214,6 @@ instance (Hashable a, Eq a) => Monoid (HashSet a) where
     {-# INLINE mempty #-}
     mappend = (<>)
     {-# INLINE mappend #-}
-    mconcat = unions
-    {-# INLINE mconcat #-}
 
 instance (Eq a, Hashable a, Read a) => Read (HashSet a) where
     readPrec = parens $ prec 10 $ do

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -95,15 +95,14 @@ import Data.HashMap.Internal
   ( HashMap, foldMapWithKey, foldlWithKey, foldrWithKey
   , equalKeys, equalKeys1)
 import Data.Hashable (Hashable(hashWithSalt))
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup (Semigroup(..))
-#endif
+import Data.Semigroup (Semigroup(..), stimesIdempotentMonoid)
 import GHC.Exts (build)
 import qualified GHC.Exts as Exts
 import Prelude hiding (filter, foldr, foldl, map, null)
 import qualified Data.Foldable as Foldable
 import qualified Data.HashMap.Internal as H
 import qualified Data.List as List
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Typeable (Typeable)
 import Text.Read
 
@@ -195,6 +194,10 @@ instance Foldable.Foldable HashSet where
 instance (Hashable a, Eq a) => Semigroup (HashSet a) where
     (<>) = union
     {-# INLINE (<>) #-}
+    sconcat = mconcat . NonEmpty.toList
+    {-# INLINE sconcat #-}
+    stimes = stimesIdempotentMonoid
+    {-# INLINE stimes #-}
 
 -- | 'mempty' = 'empty'
 --
@@ -214,6 +217,8 @@ instance (Hashable a, Eq a) => Monoid (HashSet a) where
     {-# INLINE mempty #-}
     mappend = (<>)
     {-# INLINE mappend #-}
+    mconcat = unions
+    {-# INLINE mconcat #-}
 
 instance (Eq a, Hashable a, Read a) => Read (HashSet a) where
     readPrec = parens $ prec 10 $ do


### PR DESCRIPTION
Resolves part of #307.

I added `INLINE` pragmas, for consistency with the other definitions, although they're probably not needed.

Also removed two unused `{-# LANGUAGE LambdaCase #-}`.

EDIT: I originally also added definitions for `mconcat` and `sconcat`, but removed them again (see discussion below).