### PR TITLE
Remove Typeable deriving crud

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns, CPP, DeriveDataTypeable, MagicHash #-}
+{-# LANGUAGE BangPatterns, CPP, MagicHash #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RoleAnnotations #-}
@@ -143,7 +143,7 @@ import Data.Semigroup (Semigroup((<>)))
 import Control.DeepSeq (NFData(rnf))
 import Control.Monad.ST (ST, runST)
 import Data.Bits ((.&.), (.|.), complement, popCount, unsafeShiftL, unsafeShiftR)
-import Data.Data hiding (Typeable)
+import Data.Data
 import qualified Data.Foldable as Foldable
 #if MIN_VERSION_base(4,10,0)
 import Data.Bifoldable
@@ -157,7 +157,6 @@ import qualified Data.HashMap.Internal.Array as A
 import qualified Data.Hashable as H
 import Data.Hashable (Hashable)
 import Data.HashMap.Internal.List (isPermutationBy, unorderedCompare)
-import Data.Typeable (Typeable)
 
 import GHC.Exts (isTrue#)
 import qualified GHC.Exts as Exts
@@ -215,7 +214,6 @@ data HashMap k v
     | Leaf !Hash !(Leaf k v)
     | Full !(A.Array (HashMap k v))
     | Collision !Hash !(A.Array (Leaf k v))
-      deriving (Typeable)
 
 type role HashMap nominal representational
 

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, DeriveDataTypeable #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE Trustworthy #-}
@@ -89,7 +89,7 @@ module Data.HashSet.Internal
     ) where
 
 import Control.DeepSeq (NFData(..))
-import Data.Data hiding (Typeable)
+import Data.Data
 import Data.Functor.Classes
 import Data.HashMap.Internal
   ( HashMap, foldMapWithKey, foldlWithKey, foldrWithKey
@@ -104,7 +104,6 @@ import Prelude hiding (filter, foldr, foldl, map, null)
 import qualified Data.Foldable as Foldable
 import qualified Data.HashMap.Internal as H
 import qualified Data.List as List
-import Data.Typeable (Typeable)
 import Text.Read
 
 #if MIN_VERSION_hashable(1,2,5)
@@ -118,7 +117,7 @@ import qualified Control.DeepSeq as NF
 -- | A set of values.  A set cannot contain duplicate values.
 newtype HashSet a = HashSet {
       asMap :: HashMap a ()
-    } deriving (Typeable)
+    }
 
 type role HashSet nominal
 


### PR DESCRIPTION
* We no longer need to derive `Typeable` explicitly, so let's not.
* Add a definition of `dataCast1` for `Data.HashMap`. Previously, it got the useless `const Nothing` default.