### PR TITLE
Drop support for hashable < 1.2.5

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -163,9 +163,7 @@ import qualified GHC.Exts as Exts
 import Data.Functor.Classes
 import GHC.Stack
 
-#if MIN_VERSION_hashable(1,2,5)
 import qualified Data.Hashable.Lifted as H
-#endif
 
 import qualified Control.DeepSeq as NF
 
@@ -486,7 +484,6 @@ equalKeys = go
 
     leafEq (L k1 _) (L k2 _) = k1 == k2
 
-#if MIN_VERSION_hashable(1,2,5)
 instance H.Hashable2 HashMap where
     liftHashWithSalt2 hk hv salt hm = go salt (toList' hm [])
       where
@@ -512,7 +509,6 @@ instance H.Hashable2 HashMap where
 
 instance (Hashable k) => H.Hashable1 (HashMap k) where
     liftHashWithSalt = H.liftHashWithSalt2 H.hashWithSalt
-#endif
 
 instance (Hashable k, Hashable v) => Hashable (HashMap k v) where
     hashWithSalt salt hm = go salt hm

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -106,9 +106,7 @@ import qualified Data.HashMap.Internal as H
 import qualified Data.List as List
 import Text.Read
 
-#if MIN_VERSION_hashable(1,2,5)
 import qualified Data.Hashable.Lifted as H
-#endif
 
 import qualified Control.DeepSeq as NF
 import qualified Language.Haskell.TH.Syntax as TH
@@ -241,10 +239,8 @@ instance (Data a, Eq a, Hashable a) => Data (HashSet a) where
     dataTypeOf _   = hashSetDataType
     dataCast1 f    = gcast1 f
 
-#if MIN_VERSION_hashable(1,2,6)
 instance H.Hashable1 HashSet where
     liftHashWithSalt h s = H.liftHashWithSalt2 h hashWithSalt s . asMap
-#endif
 
 instance (Hashable a) => Hashable (HashSet a) where
     hashWithSalt salt = hashWithSalt salt . asMap

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -55,7 +55,7 @@ library
   build-depends:
     base >= 4.10 && < 5,
     deepseq >= 1.4.3,
-    hashable >= 1.0.1.1 && < 1.5,
+    hashable >= 1.2.5 && < 1.5,
     template-haskell < 2.19
 
   default-language: Haskell2010
@@ -89,7 +89,7 @@ test-suite unordered-containers-tests
     base,
     ChasingBottoms,
     containers >= 0.5.8,
-    hashable >= 1.0.1.1,
+    hashable,
     HUnit,
     QuickCheck >= 2.4.0.1,
     random,
@@ -116,8 +116,8 @@ benchmark benchmarks
     base >= 4.8.0,
     bytestring >= 0.10.0.0,
     containers,
-    deepseq >= 1.4,
-    hashable >= 1.0.1.1,
+    deepseq,
+    hashable,
     hashmap,
     mtl,
     random,


### PR DESCRIPTION
Stackage snapshots for GHC 8.2 use hashable-1.2.7.0, so this shouldn't
cause any problems.