### PR TITLE
Prepare release 0.2.17.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,14 @@
 
 * [Expose internal constructors for `HashSet`, `Array` and `MArray`](https://github.com/haskell-unordered-containers/unordered-containers/pull/347)
 
+* [Tweak internal `Array.insertM` function](https://github.com/haskell-unordered-containers/unordered-containers/pull/359)
+
+* [Drop support for GHC 8.0](https://github.com/haskell-unordered-containers/unordered-containers/pull/354)
+
+* [Drop support for `hashable < 1.2.5`](https://github.com/haskell-unordered-containers/unordered-containers/pull/355)
+
+* Various cleanup and documentation improvements
+
 [0.2.17.0]: https://github.com/haskell-unordered-containers/unordered-containers/compare/v0.2.16.0...v0.2.17.0
 
 ## [0.2.16.0]

--- a/Data/HashMap/Internal/Array.hs
+++ b/Data/HashMap/Internal/Array.hs
@@ -489,6 +489,7 @@ fromList' n xs0 =
     go (!x:xs) mary i = do write mary i x
                            go xs mary (i+1)
 
+-- | @since 0.2.17.0
 instance TH.Lift a => TH.Lift (Array a) where
 #if MIN_VERSION_template_haskell(2,16,0)
   liftTyped ar = [|| fromList' arlen arlist ||]

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -1,5 +1,5 @@
 name:           unordered-containers
-version:        0.2.16.0
+version:        0.2.17.0
 synopsis:       Efficient hashing-based container types
 description:
   Efficient hashing-based container types.  The containers have been


### PR DESCRIPTION
Hackage candidate: https://hackage.haskell.org/package/unordered-containers-0.2.17.0/candidate