### PR TITLE
Internal.Array: Don't return MArrays from loops 

### DIFF
--- a/Data/HashMap/Internal/Array.hs
+++ b/Data/HashMap/Internal/Array.hs
@@ -442,9 +442,10 @@ map f = \ ary ->
     in run $ do
         mary <- new_ n
         go ary mary 0 n
+        return mary
   where
     go ary mary i n
-        | i >= n    = return mary
+        | i >= n    = return ()
         | otherwise = do
              x <- indexM ary i
              write mary i $ f x
@@ -458,9 +459,10 @@ map' f = \ ary ->
     in run $ do
         mary <- new_ n
         go ary mary 0 n
+        return mary
   where
     go ary mary i n
-        | i >= n    = return mary
+        | i >= n    = return ()
         | otherwise = do
              x <- indexM ary i
              write mary i $! f x
@@ -473,10 +475,11 @@ fromList n xs0 =
         run $ do
             mary <- new_ n
             go xs0 mary 0
+            return mary
   where
-    go [] !mary !_   = return mary
-    go (x:xs) mary i = do write mary i x
-                          go xs mary (i+1)
+    go []     !_   !_ = return ()
+    go (x:xs) mary i  = do write mary i x
+                           go xs mary (i+1)
 
 fromList' :: Int -> [a] -> Array a
 fromList' n xs0 =
@@ -484,10 +487,11 @@ fromList' n xs0 =
         run $ do
             mary <- new_ n
             go xs0 mary 0
+            return mary
   where
-    go [] !mary !_   = return mary
-    go (!x:xs) mary i = do write mary i x
-                           go xs mary (i+1)
+    go []      !_   !_ = return ()
+    go (!x:xs) mary i  = do write mary i x
+                            go xs mary (i+1)
 
 -- | @since 0.2.17.0
 instance TH.Lift a => TH.Lift (Array a) where

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -68,6 +68,7 @@ library
     BangPatterns
 
   ghc-options: -Wall -O2 -fwarn-tabs -ferror-spans
+  ghc-options: -ddump-simpl -ddump-to-file -dsuppress-coercions -dsuppress-unfoldings -dsuppress-module-prefixes -dsuppress-uniques
 
   if flag(debug)
     cpp-options: -DASSERTS
@@ -129,6 +130,7 @@ benchmark benchmarks
   if impl(ghc >= 8.10)
     ghc-options: "-with-rtsopts=-A32m --nonmoving-gc"
   -- cpp-options: -DBENCH_containers_Map -DBENCH_containers_IntMap -DBENCH_hashmap_Map
+  ghc-options: -ddump-simpl -ddump-to-file -dsuppress-coercions -dsuppress-unfoldings -dsuppress-module-prefixes -dsuppress-uniques
 
 source-repository head
   type:     git


### PR DESCRIPTION
This prevents unnecessary MArray boxing.

(Extracted from #230.)