### PR TITLE
Fix space leaks in `union[With[Key]]` (#379)

### DIFF
--- a/tests/Regressions.hs
+++ b/tests/Regressions.hs
@@ -137,6 +137,22 @@ issue379Union = do
   mThunkInfo <- noThunksInValues mempty (Foldable.toList u)
   assert $ isNothing mThunkInfo
 
+issue379UnionWith :: Assertion
+issue379UnionWith = do
+  let m0 = HMS.fromList [(KC 1, 10), (KC 2, 20 :: Int)]
+  let m1 = HMS.fromList [(KC 2, 20), (KC 3, 30)]
+  let u = HMS.unionWith (+) m0 m1
+  mThunkInfo <- noThunksInValues mempty (Foldable.toList u)
+  assert $ isNothing mThunkInfo
+
+issue379UnionWithKey :: Assertion
+issue379UnionWithKey = do
+  let m0 = HMS.fromList [(KC 1, 10), (KC 2, 20 :: Int)]
+  let m1 = HMS.fromList [(KC 2, 20), (KC 3, 30)]
+  let u = HMS.unionWithKey (\(KC i) v0 v1 -> i + v0 + v1) m0 m1
+  mThunkInfo <- noThunksInValues mempty (Foldable.toList u)
+  assert $ isNothing mThunkInfo
+
 ------------------------------------------------------------------------
 -- * Test list
 
@@ -148,5 +164,9 @@ tests = testGroup "Regression tests"
     , testProperty "issue39b" propEqAfterDelete
     , testCase "issue254 lazy" issue254Lazy
     , testCase "issue254 strict" issue254Strict
-    , testCase "issue379Union" issue379Union
+    , testGroup "issue379"
+          [ testCase "union" issue379Union
+          , testCase "unionWith" issue379UnionWith
+          , testCase "unionWithKey" issue379UnionWithKey
+          ]
     ]

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -91,6 +91,7 @@ test-suite unordered-containers-tests
     containers >= 0.5.8,
     hashable,
     HUnit,
+    nothunks >= 0.1.3,
     QuickCheck >= 2.4.0.1,
     random,
     tasty >= 1.4.0.3,


### PR DESCRIPTION
Fixes #379