### PR TITLE
Strict.mapMaybe[WithKey]: Fix strictness for collisions

### DIFF
--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -548,7 +548,7 @@ mapMaybeWithKey f = filterMapAux onLeaf onColl
   where onLeaf (Leaf h (L k v)) | Just v' <- f k v = Just (leaf h k v')
         onLeaf _ = Nothing
 
-        onColl (L k v) | Just v' <- f k v = Just (L k v')
+        onColl (L k v) | Just !v' <- f k v = Just (L k v')
                        | otherwise = Nothing
 {-# INLINE mapMaybeWithKey #-}
 

--- a/tests/Regressions.hs
+++ b/tests/Regressions.hs
@@ -190,7 +190,7 @@ issue379LazyUnionWith = do
 ------------------------------------------------------------------------
 -- Issue #381
 
-#if MIN_VERSION_base(4,12,0)
+#ifdef HAVE_NOTHUNKS
 
 issue381mapMaybe :: Assertion
 issue381mapMaybe = do
@@ -227,7 +227,7 @@ tests = testGroup "Regression tests"
           , testCase "Strict.unionWithKey" issue379StrictUnionWithKey
 #endif
           ]
-#if MIN_VERSION_base(4,12,0)
+#ifdef HAVE_NOTHUNKS
     , testGroup "issue381"
           [ testCase "mapMaybe" issue381mapMaybe
           , testCase "mapMaybeWithKey" issue381mapMaybeWithKey

--- a/tests/Regressions.hs
+++ b/tests/Regressions.hs
@@ -188,6 +188,27 @@ issue379LazyUnionWith = do
   assert $ isNothing res
 
 ------------------------------------------------------------------------
+-- Issue #381
+
+#if MIN_VERSION_base(4,12,0)
+
+issue381mapMaybe :: Assertion
+issue381mapMaybe = do
+  let m0 = HMS.fromList [(KC 1, 10), (KC 2, 20 :: Int)]
+  let m1 = HMS.mapMaybe (Just . (+ 1)) m0
+  mThunkInfo <- noThunksInValues mempty (Foldable.toList m1)
+  assert $ isNothing mThunkInfo
+
+issue381mapMaybeWithKey :: Assertion
+issue381mapMaybeWithKey = do
+  let m0 = HMS.fromList [(KC 1, 10), (KC 2, 20 :: Int)]
+  let m1 = HMS.mapMaybeWithKey (\(KC k) v -> Just (k + v)) m0
+  mThunkInfo <- noThunksInValues mempty (Foldable.toList m1)
+  assert $ isNothing mThunkInfo
+
+#endif
+
+------------------------------------------------------------------------
 -- * Test list
 
 tests :: TestTree
@@ -206,4 +227,10 @@ tests = testGroup "Regression tests"
           , testCase "Strict.unionWithKey" issue379StrictUnionWithKey
 #endif
           ]
+#if MIN_VERSION_base(4,12,0)
+    , testGroup "issue381"
+          [ testCase "mapMaybe" issue381mapMaybe
+          , testCase "mapMaybeWithKey" issue381mapMaybeWithKey
+          ]
+#endif
     ]


### PR DESCRIPTION
Fixes https://github.com/haskell-unordered-containers/unordered-containers/issues/381.