### PR TITLE
Improve docs of bit twiddling functions

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2418,7 +2418,7 @@ mask w s = 1 `unsafeShiftL` index w s
 {-# INLINE mask #-}
 
 -- | Given a 'Hash' and a 'Shift' that indicates the level in the tree, compute
--- the index into a 'Full' node or into the bitmap of of `BitmapIndexed` node.
+-- the index into a 'Full' node or into the bitmap of a `BitmapIndexed` node.
 --
 -- >>> index 0b0010_0010 0
 -- 0b0000_0010

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2405,6 +2405,9 @@ sparseIndex b m = popCount (b .&. (m - 1))
 -- | Given a 'Hash' and a 'Shift' that indicates the level in the tree, compute
 -- the bitmap that contains only the 'index' of the hash at this level.
 --
+-- The result can be used for constructing one-element 'BitmapIndexed' nodes or
+-- to check whether a 'BitmapIndexed' node may possibly contain the given 'Hash'.
+--
 -- >>> mask 0b0010_0010 0
 -- 0b0100
 mask

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2361,22 +2361,28 @@ clone ary =
 bitsPerSubkey :: Int
 bitsPerSubkey = 5
 
+-- | The size of a 'Full' node, @2 ^ 'bitsPerSubkey'@.
 maxChildren :: Int
 maxChildren = 1 `unsafeShiftL` bitsPerSubkey
 
+-- | Bitmap with the lowest 'bitsPerSubkey' set, e.g. @0b11111@.
 subkeyMask :: Bitmap
 subkeyMask = 1 `unsafeShiftL` bitsPerSubkey - 1
 
+-- | Number of bits of the first...
 sparseIndex :: Bitmap -> Bitmap -> Int
 sparseIndex b m = popCount (b .&. (m - 1))
 {-# INLINE sparseIndex #-}
 
-mask :: Word -> Shift -> Bitmap
+-- | A single bit set at the 'Full' node index.
+mask :: Hash -> Shift -> Bitmap
 mask w s = 1 `unsafeShiftL` index w s
 {-# INLINE mask #-}
 
 -- | Mask out the 'bitsPerSubkey' bits used for indexing at this level
 -- of the tree.
+--
+-- The result is the index of the hash into the array of a 'Full' node.
 index :: Hash -> Shift -> Int
 index w s = fromIntegral $ unsafeShiftR w s .&. subkeyMask
 {-# INLINE index #-}

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2375,12 +2375,12 @@ subkeyMask = 1 `unsafeShiftL` bitsPerSubkey - 1
 --
 -- >>> sparseIndex 0b0110_0110 0b0010_0000
 -- 2
-sparseIndex ::
-    Bitmap ->
+sparseIndex
+    :: Bitmap
     -- ^ Bitmap of a 'BitmapIndexed' node
-    Bitmap ->
+    -> Bitmap
     -- ^ One-bit 'mask' corresponding to the 'index' of a hash
-    Int
+    -> Int
     -- ^ Index into the array of the 'BitmapIndexed' node
 sparseIndex b m = popCount (b .&. (m - 1))
 {-# INLINE sparseIndex #-}

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2366,8 +2366,8 @@ bitsPerSubkey = 5
 maxChildren :: Int
 maxChildren = 1 `unsafeShiftL` bitsPerSubkey
 
--- | Bitmap with the lowest 'bitsPerSubkey' bits set, i.e. @0b11111@.
-subkeyMask :: Bitmap
+-- | Bit mask with the lowest 'bitsPerSubkey' bits set, i.e. @0b11111@.
+subkeyMask :: Word
 subkeyMask = 1 `unsafeShiftL` bitsPerSubkey - 1
 
 -- | This array index is computed by counting the number of bits below the

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2410,10 +2410,7 @@ sparseIndex b m = popCount (b .&. (m - 1))
 --
 -- >>> mask 0b0010_0010 0
 -- 0b0100
-mask
-    :: Hash
-    -> Shift
-    -> Bitmap
+mask :: Hash -> Shift -> Bitmap
 mask w s = 1 `unsafeShiftL` index w s
 {-# INLINE mask #-}
 
@@ -2422,10 +2419,7 @@ mask w s = 1 `unsafeShiftL` index w s
 --
 -- >>> index 0b0010_0010 0
 -- 0b0000_0010
-index
-    :: Hash
-    -> Shift
-    -> Int
+index :: Hash -> Shift -> Int
 index w s = fromIntegral $ unsafeShiftR w s .&. subkeyMask
 {-# INLINE index #-}
 

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2387,6 +2387,27 @@ maxChildren = 1 `unsafeShiftL` bitsPerSubkey
 subkeyMask :: Word
 subkeyMask = 1 `unsafeShiftL` bitsPerSubkey - 1
 
+-- | Given a 'Hash' and a 'Shift' that indicates the level in the tree, compute
+-- the index into a 'Full' node or into the bitmap of a `BitmapIndexed` node.
+--
+-- >>> index 0b0010_0010 0
+-- 0b0000_0010
+index :: Hash -> Shift -> Int
+index w s = fromIntegral $ unsafeShiftR w s .&. subkeyMask
+{-# INLINE index #-}
+
+-- | Given a 'Hash' and a 'Shift' that indicates the level in the tree, compute
+-- the bitmap that contains only the 'index' of the hash at this level.
+--
+-- The result can be used for constructing one-element 'BitmapIndexed' nodes or
+-- to check whether a 'BitmapIndexed' node may possibly contain the given 'Hash'.
+--
+-- >>> mask 0b0010_0010 0
+-- 0b0100
+mask :: Hash -> Shift -> Bitmap
+mask w s = 1 `unsafeShiftL` index w s
+{-# INLINE mask #-}
+
 -- | This array index is computed by counting the number of bits below the
 -- 'index' represented by the mask.
 --
@@ -2401,27 +2422,6 @@ sparseIndex
     -- ^ Index into the array of the 'BitmapIndexed' node
 sparseIndex b m = popCount (b .&. (m - 1))
 {-# INLINE sparseIndex #-}
-
--- | Given a 'Hash' and a 'Shift' that indicates the level in the tree, compute
--- the bitmap that contains only the 'index' of the hash at this level.
---
--- The result can be used for constructing one-element 'BitmapIndexed' nodes or
--- to check whether a 'BitmapIndexed' node may possibly contain the given 'Hash'.
---
--- >>> mask 0b0010_0010 0
--- 0b0100
-mask :: Hash -> Shift -> Bitmap
-mask w s = 1 `unsafeShiftL` index w s
-{-# INLINE mask #-}
-
--- | Given a 'Hash' and a 'Shift' that indicates the level in the tree, compute
--- the index into a 'Full' node or into the bitmap of a `BitmapIndexed` node.
---
--- >>> index 0b0010_0010 0
--- 0b0000_0010
-index :: Hash -> Shift -> Int
-index w s = fromIntegral $ unsafeShiftR w s .&. subkeyMask
-{-# INLINE index #-}
 
 -- TODO: Should be named _(bit)map_ instead of _mask_
 

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2375,7 +2375,7 @@ clone ary =
 
 -- | Number of bits that are inspected at each level of the hash tree.
 --
--- This constant is named _t_ in the original _Ideal Hash Trees_ paper.
+-- This constant is named /t/ in the original /Ideal Hash Trees/ paper.
 bitsPerSubkey :: Int
 bitsPerSubkey = 5
 


### PR DESCRIPTION
Fixes #394.

---

TODO:

* [x] Add docs for `Hash`, `Bitmap`, `Shift` types
* [x] ~~Add `incrementShift s = s + bitsPerSubkey`?!~~ Moved to #426.