### PR TITLE
Tests: Increase variation in generated tree shapes

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.1
+# version: 0.14.3
 #
-# REGENDATA ("0.14.1",["github","unordered-containers.cabal"])
+# REGENDATA ("0.14.3",["github","unordered-containers.cabal"])
 #
 name: Haskell-CI
 on:
@@ -50,44 +50,34 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
-          else
-            apt-add-repository -y 'ppa:hvr/ghc'
-            apt-get update
-            apt-get install -y "$HCNAME"
-            mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
-            chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
-          fi
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+          mkdir -p "$HOME/.ghcup/bin"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.17.5/x86_64-linux-ghcup-0.1.17.5 > "$HOME/.ghcup/bin/ghcup"
+          chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -99,20 +89,11 @@ jobs:
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
-          if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          else
-            HC=$HCDIR/bin/$HCKIND
-            echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
-          fi
-
+          HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.6.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1906,7 +1906,7 @@ intersectionCollisions f h1 h2 ary1 ary2
     case len of
       0 -> pure Empty
       1 -> Leaf h1 <$> A.read mary 0
-      _ -> Collision h1 <$> (A.unsafeFreeze =<< A.shrink mary (len-1))
+      _ -> Collision h1 <$> (A.unsafeFreeze =<< A.shrink mary len)
   | otherwise = Empty
 {-# INLINE intersectionCollisions #-}
 

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1906,7 +1906,7 @@ intersectionCollisions f h1 h2 ary1 ary2
     case len of
       0 -> pure Empty
       1 -> Leaf h1 <$> A.read mary 0
-      _ -> Collision h1 <$> (A.unsafeFreeze =<< A.shrink mary len)
+      _ -> Collision h1 <$> (A.unsafeFreeze =<< A.shrink mary (len-1))
   | otherwise = Empty
 {-# INLINE intersectionCollisions #-}
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -9,3 +9,6 @@ constraint-set debug
 
 installed: -containers
 installed: -binary
+
+-- Avoid HVR's PPA due to outage on 2022-04-27
+ghcup-jobs: True

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -62,7 +62,13 @@ data SmallSum = A | B | C | D
 
 instance Arbitrary SmallSum where
   arbitrary = QC.arbitraryBoundedEnum
-  shrink = QC.genericShrink
+  shrink = shrinkSmallSum
+
+shrinkSmallSum :: SmallSum -> [SmallSum]
+shrinkSmallSum A = []
+shrinkSmallSum B = [A]
+shrinkSmallSum C = [A, B]
+shrinkSmallSum D = [A, B, C]
 
 instance Arbitrary Key where
   arbitrary = K <$> arbitraryHash <*> arbitrary

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -18,7 +18,7 @@ module MODULE_NAME (tests) where
 import Control.Applicative      (Const (..))
 import Control.Monad            (guard)
 import Data.Bifoldable
-import Data.Bits                (shiftL, (.&.))
+import Data.Bits                (bit, (.&.))
 import Data.Function            (on)
 import Data.Functor.Identity    (Identity (..))
 import Data.Hashable            (Hashable (hashWithSalt))
@@ -84,7 +84,7 @@ moreCollisions :: Int -> Int
 moreCollisions w = fromIntegral (w .&. mask)
 
 mask :: Int
-mask = sum [1 `shiftL` n | n <- [0, 3, 8, 14, 61]]
+mask = sum [bit n | n <- [0, 3, 8, 14, 61]]
 
 instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v) where
   arbitrary = fmap (HM.fromList) arbitrary

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -374,7 +374,7 @@ pIntersectionWithKey xs ys = M.intersectionWithKey go (M.fromList xs) `eq_`
                              HM.intersectionWithKey go (HM.fromList xs) $ ys
   where
     go :: Key -> Int -> Int -> Int
-    go (K h _) i1 i2 = h - i1 - i2
+    go k i1 i2 = keyToInt k - i1 - i2
 
 ------------------------------------------------------------------------
 -- ** Folds

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -50,15 +50,19 @@ import qualified Data.Map.Lazy     as M
 data Key = K
   { hash :: !Int
     -- ^ The hash of the key
-  , _s :: !SmallSum
+  , _x :: !SmallSum
     -- ^ Additional data, so we can have collisions for any hash
   } deriving (Eq, Ord, Read, Show, Generic)
+
+instance Hashable Key where
+  hashWithSalt _ (K h _) = h
 
 data SmallSum = A | B | C | D
   deriving (Eq, Ord, Read, Show, Generic, Enum, Bounded)
 
 instance Arbitrary SmallSum where
   arbitrary = QC.arbitraryBoundedEnum
+  shrink = QC.genericShrink
 
 instance Arbitrary Key where
   arbitrary = K <$> arbitraryHash <*> arbitrary
@@ -81,9 +85,6 @@ moreCollisions w = fromIntegral (w .&. mask)
 
 mask :: Int
 mask = sum [1 `shiftL` n | n <- [0, 3, 8, 14, 61]]
-
-instance Hashable Key where
-  hashWithSalt _ (K h _) = h
 
 instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v) where
   arbitrary = fmap (HM.fromList) arbitrary

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -92,11 +92,11 @@ moreCollisions w = fromIntegral (w .&. mask)
 mask :: Int
 mask = sum [bit n | n <- [0, 3, 8, 14, 61]]
 
-instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v) where
-  arbitrary = fmap (HM.fromList) arbitrary
-
 keyToInt :: Key -> Int
 keyToInt (K h x) = h * fromEnum x
+
+instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v) where
+  arbitrary = fmap (HM.fromList) arbitrary
 
 ------------------------------------------------------------------------
 -- * Properties

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeApplications           #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-} -- because of Arbitrary (HashMap k v)
@@ -44,7 +43,8 @@ import qualified Data.Map.Lazy     as M
 #endif
 
 instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v) where
-  arbitrary = fmap (HM.fromList) arbitrary
+  arbitrary = HM.fromList <$> arbitrary
+  shrink = fmap HM.fromList . shrink . HM.toList
 
 ------------------------------------------------------------------------
 -- * Properties

--- a/tests/Properties/HashSet.hs
+++ b/tests/Properties/HashSet.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-
 -- | Tests for the 'Data.HashSet' module.  We test functions by
 -- comparing them to @Set@ from @containers@.
 
@@ -8,21 +5,15 @@ module Properties.HashSet (tests) where
 
 import Data.Hashable         (Hashable (hashWithSalt))
 import Data.Ord              (comparing)
-import Test.QuickCheck       (Arbitrary, Property, property, (===), (==>))
+import Test.QuickCheck       (Property, property, (===), (==>))
 import Test.Tasty            (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+import Util.Key              (Key, incKey, keyToInt)
 
 import qualified Data.Foldable as Foldable
 import qualified Data.HashSet  as S
 import qualified Data.List     as List
 import qualified Data.Set      as Set
-
--- Key type that generates more hash collisions.
-newtype Key = K { unK :: Int }
-            deriving (Arbitrary, Enum, Eq, Integral, Num, Ord, Read, Show, Real)
-
-instance Hashable Key where
-    hashWithSalt salt k = hashWithSalt salt (unK k) `mod` 20
 
 ------------------------------------------------------------------------
 -- * Properties
@@ -128,7 +119,7 @@ pUnion xs ys = Set.union (Set.fromList xs) `eq_`
 -- ** Transformations
 
 pMap :: [Key] -> Property
-pMap = Set.map (+ 1) `eq_` S.map (+ 1)
+pMap = Set.map incKey `eq_` S.map incKey
 
 ------------------------------------------------------------------------
 -- ** Folds
@@ -150,7 +141,9 @@ foldl'Set = Set.foldl'
 -- ** Filter
 
 pFilter :: [Key] -> Property
-pFilter = Set.filter odd `eq_` S.filter odd
+pFilter = Set.filter p `eq_` S.filter p
+  where
+    p = odd . keyToInt
 
 ------------------------------------------------------------------------
 -- ** Conversions

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-} -- because of Arbitrary (HashMap k v)
 
 module Strictness (tests) where
 

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Strictness (tests) where
@@ -8,7 +6,7 @@ module Strictness (tests) where
 import Control.Arrow                (second)
 import Control.Monad                (guard)
 import Data.Foldable                (foldl')
-import Data.Hashable                (Hashable (hashWithSalt))
+import Data.Hashable                (Hashable)
 import Data.HashMap.Strict          (HashMap)
 import Data.Maybe                   (fromMaybe, isJust)
 import Test.ChasingBottoms.IsBottom
@@ -18,15 +16,9 @@ import Test.QuickCheck.Function
 import Test.QuickCheck.Poly         (A)
 import Test.Tasty                   (TestTree, testGroup)
 import Test.Tasty.QuickCheck        (testProperty)
+import Util.Key                     (Key)
 
 import qualified Data.HashMap.Strict as HM
-
--- Key type that generates more hash collisions.
-newtype Key = K { unK :: Int }
-            deriving (Arbitrary, Eq, Ord, Show)
-
-instance Hashable Key where
-    hashWithSalt salt k = hashWithSalt salt (unK k) `mod` 20
 
 instance (Arbitrary k, Arbitrary v, Eq k, Hashable k) =>
          Arbitrary (HashMap k v) where
@@ -84,8 +76,8 @@ pInsertWithValueStrict f k v m
 pFromListKeyStrict :: Bool
 pFromListKeyStrict = isBottom $ HM.fromList [(undefined :: Key, 1 :: Int)]
 
-pFromListValueStrict :: Bool
-pFromListValueStrict = isBottom $ HM.fromList [(K 1, undefined)]
+pFromListValueStrict :: Key -> Bool
+pFromListValueStrict k = isBottom $ HM.fromList [(k, undefined)]
 
 pFromListWithKeyStrict :: (Int -> Int -> Int) -> Bool
 pFromListWithKeyStrict f =

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -9,8 +9,7 @@ import Data.Hashable                (Hashable)
 import Data.HashMap.Strict          (HashMap)
 import Data.Maybe                   (fromMaybe, isJust)
 import Test.ChasingBottoms.IsBottom
-import Test.QuickCheck              (Arbitrary (arbitrary), Property, (.&&.),
-                                     (===))
+import Test.QuickCheck              (Arbitrary (..), Property, (.&&.), (===))
 import Test.QuickCheck.Function
 import Test.QuickCheck.Poly         (A)
 import Test.Tasty                   (TestTree, testGroup)
@@ -20,9 +19,9 @@ import Util.Key                     (Key)
 
 import qualified Data.HashMap.Strict as HM
 
-instance (Arbitrary k, Arbitrary v, Eq k, Hashable k) =>
-         Arbitrary (HashMap k v) where
-    arbitrary = HM.fromList `fmap` arbitrary
+instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v) where
+  arbitrary = HM.fromList <$> arbitrary
+  shrink = fmap HM.fromList . shrink . HM.toList
 
 ------------------------------------------------------------------------
 -- * Properties

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Strictness (tests) where
@@ -16,6 +15,7 @@ import Test.QuickCheck.Function
 import Test.QuickCheck.Poly         (A)
 import Test.Tasty                   (TestTree, testGroup)
 import Test.Tasty.QuickCheck        (testProperty)
+import Text.Show.Functions          ()
 import Util.Key                     (Key)
 
 import qualified Data.HashMap.Strict as HM
@@ -23,12 +23,6 @@ import qualified Data.HashMap.Strict as HM
 instance (Arbitrary k, Arbitrary v, Eq k, Hashable k) =>
          Arbitrary (HashMap k v) where
     arbitrary = HM.fromList `fmap` arbitrary
-
-instance Show (Int -> Int) where
-    show _ = "<function>"
-
-instance Show (Int -> Int -> Int) where
-    show _ = "<function>"
 
 ------------------------------------------------------------------------
 -- * Properties

--- a/tests/Util/Key.hs
+++ b/tests/Util/Key.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Util.Key (Key(..), keyToInt, incKey) where
+module Util.Key (Key(..), keyToInt, incKey, collisionAtHash) where
 
 import Data.Bits       (bit, (.&.))
 import Data.Hashable   (Hashable (hashWithSalt))
@@ -62,3 +62,7 @@ keyToInt (K h x) = h * fromEnum x
 
 incKey :: Key -> Key
 incKey (K h x) = K (h + 1) x
+
+-- | 4 colliding keys at a given hash.
+collisionAtHash :: Int -> (Key, Key, Key, Key)
+collisionAtHash h = (K h A, K h B, K h C, K h D)

--- a/tests/Util/Key.hs
+++ b/tests/Util/Key.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Util.Key where
+module Util.Key (Key(..), keyToInt, incKey) where
 
 import Data.Bits       (bit, (.&.))
 import Data.Hashable   (Hashable (hashWithSalt))

--- a/tests/Util/Key.hs
+++ b/tests/Util/Key.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE DeriveGeneric    #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Util.Key where
+
+import Data.Bits       (bit, (.&.))
+import Data.Hashable   (Hashable (hashWithSalt))
+import Data.Word       (Word16)
+import GHC.Generics    (Generic)
+import Test.QuickCheck (Arbitrary (..), Gen, Large)
+
+import qualified Test.QuickCheck as QC
+
+-- Key type that generates more hash collisions.
+data Key = K
+  { hash :: !Int
+    -- ^ The hash of the key
+  , _x :: !SmallSum
+    -- ^ Additional data, so we can have collisions for any hash
+  } deriving (Eq, Ord, Read, Show, Generic)
+
+instance Hashable Key where
+  hashWithSalt _ (K h _) = h
+
+data SmallSum = A | B | C | D
+  deriving (Eq, Ord, Read, Show, Generic, Enum, Bounded)
+
+instance Arbitrary SmallSum where
+  arbitrary = QC.arbitraryBoundedEnum
+  shrink = shrinkSmallSum
+
+shrinkSmallSum :: SmallSum -> [SmallSum]
+shrinkSmallSum A = []
+shrinkSmallSum B = [A]
+shrinkSmallSum C = [A, B]
+shrinkSmallSum D = [A, B, C]
+
+instance Arbitrary Key where
+  arbitrary = K <$> arbitraryHash <*> arbitrary
+  shrink = QC.genericShrink
+
+arbitraryHash :: Gen Int
+arbitraryHash = do
+  let gens =
+        [ (2, (fromIntegral . QC.getLarge) <$> arbitrary @(Large Word16))
+        , (1, QC.getSmall <$> arbitrary)
+        , (1, QC.getLarge <$> arbitrary)
+        ]
+  i <- QC.frequency gens
+  moreCollisions' <- QC.elements [moreCollisions, id]
+  pure (moreCollisions' i)
+
+-- | Mask out most bits to produce more collisions
+moreCollisions :: Int -> Int
+moreCollisions w = fromIntegral (w .&. mask)
+
+mask :: Int
+mask = sum [bit n | n <- [0, 3, 8, 14, 61]]
+
+keyToInt :: Key -> Int
+keyToInt (K h x) = h * fromEnum x
+
+incKey :: Key -> Key
+incKey (K h x) = K (h + 1) x

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -89,6 +89,7 @@ test-suite unordered-containers-tests
     Properties.HashSet
     Properties.List
     Strictness
+    Util.Key
 
   build-depends:
     base,


### PR DESCRIPTION
Addresses #438.

---

TODO:
* [x] Use the same `Key` type for `HashSet` and `Strictness` tests
* [ ] Try producing `Full` nodes?!
* [x] Check that any tests that use specific colliding keys still do the right thing.
* [x] Improve shrinking for `SmallSum` (https://github.com/nick8325/quickcheck/issues/343)