### PR TITLE
Refactor tests

### DIFF
--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -53,24 +53,6 @@ instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v)
 -- * Properties
 
 ------------------------------------------------------------------------
--- ** Folds
-
-pBifoldMap :: [(Int, Int)] -> Property
-pBifoldMap xs = concatMap f (HM.toList m) === bifoldMap (:[]) (:[]) m
-  where f (k, v) = [k, v]
-        m = HM.fromList xs
-
-pBifoldr :: [(Int, Int)] -> Property
-pBifoldr xs = concatMap f (HM.toList m) === bifoldr (:) (:) [] m
-  where f (k, v) = [k, v]
-        m = HM.fromList xs
-
-pBifoldl :: [(Int, Int)] -> Property
-pBifoldl xs = reverse (concatMap f $ HM.toList m) === bifoldl (flip (:)) (flip (:)) [] m
-  where f (k, v) = [k, v]
-        m = HM.fromList xs
-
-------------------------------------------------------------------------
 -- ** Conversions
 
 -- The free magma is used to test that operations are applied in the
@@ -139,9 +121,15 @@ tests =
           let f = List.sort . Foldable.foldr (:) []
           in  f x === f (toOrdMap x)
       , testGroup "Bifoldable"
-        [ testProperty "bifoldMap" pBifoldMap
-        , testProperty "bifoldr" pBifoldr
-        , testProperty "bifoldl" pBifoldl
+        [ testProperty "bifoldMap" $
+          \(m :: HMK Key) ->
+            bifoldMap (:[]) (:[]) m === concatMap (\(k, v) -> [k, v]) (HM.toList m)
+        , testProperty "bifoldr" $
+          \(m :: HMK Key) ->
+            bifoldr (:) (:) [] m === concatMap (\(k, v) -> [k, v]) (HM.toList m)
+        , testProperty "bifoldl" $
+          \(m :: HMK Key) ->
+            bifoldl (flip (:)) (flip (:)) [] m === reverse (concatMap (\(k, v) -> [k, v]) (HM.toList m))
         ]
       , testProperty "Hashable" $
         \(xs :: [(Key, Int)]) is salt ->

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -425,9 +425,9 @@ tests =
       , testProperty "Read/Show" $
         \(x :: HMKI) -> x === read (show x)
       , testProperty "Functor" $
-        \(x :: HMKI) ->
-          let y = fmap (+1) x
-          in  toOrdMap y === fmap (+1) (toOrdMap x)
+        \(x :: HMKI) (f :: Fun Int Int) ->
+          let y = fmap (apply f) x
+          in  toOrdMap y === fmap (apply f) (toOrdMap x)
       , testProperty "Foldable" $
         \(x :: HMKI) ->
           let f = List.sort . Foldable.foldr (:) []

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -268,7 +268,9 @@ tests =
         toOrdMap (HM.difference x y) === M.difference (toOrdMap x) (toOrdMap y)
     , testProperty "differenceWith" $
       \f (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.differenceWith (QC.applyFun2 f) x y) === M.differenceWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
+        toOrdMap (HM.differenceWith (QC.applyFun2 f) x y)
+        ===
+        M.differenceWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
     , testGroup "intersection"
       [ testProperty "model" $
         \(x :: HMKI) (y :: HMKI) ->
@@ -279,10 +281,14 @@ tests =
       ]
     , testProperty "intersectionWith" $
       \(f :: Fun (A, B) C) (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.intersectionWith (QC.applyFun2 f) x y) === M.intersectionWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
+        toOrdMap (HM.intersectionWith (QC.applyFun2 f) x y)
+        ===
+        M.intersectionWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
     , testProperty "intersectionWithKey" $
       \(f :: Fun (Key, A, B) C) (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.intersectionWithKey (QC.applyFun3 f) x y) === M.intersectionWithKey (QC.applyFun3 f) (toOrdMap x) (toOrdMap y)
+        toOrdMap (HM.intersectionWithKey (QC.applyFun3 f) x y)
+        ===
+        M.intersectionWithKey (QC.applyFun3 f) (toOrdMap x) (toOrdMap y)
     -- Transformations
     , testProperty "map" $
       \(f :: Fun A B) (m :: HMK A) -> toOrdMap (HM.map (QC.applyFun f) m) === M.map (QC.applyFun f) (toOrdMap m)

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -265,6 +265,26 @@ tests =
         in  toOrdMap z === M.unionWithKey (applyFun3 f) (toOrdMap x) (toOrdMap y)
     , testProperty "unions" $
       \(ms :: [HMKI]) -> toOrdMap (HM.unions ms) === M.unions (map toOrdMap ms)
+    , testProperty "difference" $
+      \(x :: HMKI) (y :: HMKI) ->
+        toOrdMap (HM.difference x y) === M.difference (toOrdMap x) (toOrdMap y)
+    , testProperty "differenceWith" $
+      \f (x :: HMK A) (y :: HMK B) ->
+        toOrdMap (HM.differenceWith (applyFun2 f) x y) === M.differenceWith (applyFun2 f) (toOrdMap x) (toOrdMap y)
+    , testGroup "intersection"
+      [ testProperty "model" $
+        \(x :: HMKI) (y :: HMKI) ->
+          toOrdMap (HM.intersection x y) === M.intersection (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(x :: HMKI) (y :: HMKI) ->
+          isValid (HM.intersection x y)
+      ]
+    , testProperty "intersectionWith" $
+      \(f :: Fun (A, B) C) (x :: HMK A) (y :: HMK B) ->
+        toOrdMap (HM.intersectionWith (applyFun2 f) x y) === M.intersectionWith (applyFun2 f) (toOrdMap x) (toOrdMap y)
+    , testProperty "intersectionWithKey" $
+      \(f :: Fun (Key, A, B) C) (x :: HMK A) (y :: HMK B) ->
+        toOrdMap (HM.intersectionWithKey (applyFun3 f) x y) === M.intersectionWithKey (applyFun3 f) (toOrdMap x) (toOrdMap y)
     -- Transformations
     , testProperty "map" $
       \(f :: Fun A B) (m :: HMK A) -> toOrdMap (HM.map (apply f) m) === M.map (apply f) (toOrdMap m) 
@@ -306,26 +326,6 @@ tests =
       \(m :: HMKI) ->
         let f k v = [(k, v)]
         in  sortByKey (HM.foldMapWithKey f m) === sortByKey (M.foldMapWithKey f (toOrdMap m))
-    , testProperty "difference" $
-      \(x :: HMKI) (y :: HMKI) ->
-        toOrdMap (HM.difference x y) === M.difference (toOrdMap x) (toOrdMap y)
-    , testProperty "differenceWith" $
-      \f (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.differenceWith (applyFun2 f) x y) === M.differenceWith (applyFun2 f) (toOrdMap x) (toOrdMap y)
-    , testGroup "intersection"
-      [ testProperty "model" $
-        \(x :: HMKI) (y :: HMKI) ->
-          toOrdMap (HM.intersection x y) === M.intersection (toOrdMap x) (toOrdMap y)
-      , testProperty "valid" $
-        \(x :: HMKI) (y :: HMKI) ->
-          isValid (HM.intersection x y)
-      ]
-    , testProperty "intersectionWith" $
-      \(f :: Fun (A, B) C) (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.intersectionWith (applyFun2 f) x y) === M.intersectionWith (applyFun2 f) (toOrdMap x) (toOrdMap y)
-    , testProperty "intersectionWithKey" $
-      \(f :: Fun (Key, A, B) C) (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.intersectionWithKey (applyFun3 f) x y) === M.intersectionWithKey (applyFun3 f) (toOrdMap x) (toOrdMap y)
     -- Filter
     , testProperty "filter" $
       \p (m :: HMKI) ->

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -6,7 +6,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-} -- because of Arbitrary (HashMap k v)
 
 -- | Tests for "Data.HashMap.Lazy" and "Data.HashMap.Strict".  We test functions by
--- comparing them to @Map@ from @containers@.
+-- comparing them to @Map@ from @containers@. @Map@ is referred to as the /model/
+-- for 'HashMap'
 
 #if defined(STRICT)
 #define MODULE_NAME Properties.HashMapStrict

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -50,10 +50,19 @@ instance (Eq k, Hashable k, Arbitrary k, Arbitrary v) => Arbitrary (HashMap k v)
   shrink = fmap HM.fromList . shrink . HM.toList
 
 ------------------------------------------------------------------------
--- * Properties
+-- Helpers
 
-------------------------------------------------------------------------
--- ** Conversions
+type HMK  = HashMap Key
+type HMKI = HMK Int
+
+sortByKey :: Ord k => [(k, v)] -> [(k, v)]
+sortByKey = List.sortBy (compare `on` fst)
+
+toOrdMap :: Ord k => HashMap k v -> M.Map k v
+toOrdMap = M.fromList . HM.toList
+
+isValid :: (Eq k, Hashable k, Show k) => HashMap k v -> Property
+isValid m = valid m === Valid
 
 -- The free magma is used to test that operations are applied in the
 -- same order.
@@ -67,7 +76,7 @@ instance Hashable a => Hashable (Magma a) where
   hashWithSalt s (Op m n) = hashWithSalt s (hashWithSalt (hashWithSalt (2::Int) m) n)
 
 ------------------------------------------------------------------------
--- * Test list
+-- Test list
 
 tests :: TestTree
 tests =
@@ -353,18 +362,3 @@ tests =
     , testProperty "toList" $
       \(m :: HMKI) -> List.sort (HM.toList m) === List.sort (M.toList (toOrdMap m))
     ]
-
-------------------------------------------------------------------------
--- * Helpers
-
-type HMK  = HashMap Key
-type HMKI = HMK Int
-
-sortByKey :: Ord k => [(k, v)] -> [(k, v)]
-sortByKey = List.sortBy (compare `on` fst)
-
-toOrdMap :: Ord k => HashMap k v -> M.Map k v
-toOrdMap = M.fromList . HM.toList
-
-isValid :: (Eq k, Hashable k, Show k) => HashMap k v -> Property
-isValid m = valid m === Valid

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NoMonomorphismRestriction  #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE ScopedTypeVariables       #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-} -- because of Arbitrary (HashMap k v)
 
 -- | Tests for "Data.HashMap.Lazy" and "Data.HashMap.Strict".  We test functions by

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications           #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-} -- because of Arbitrary (HashMap k v)
 
--- | Tests for the 'Data.HashMap.Lazy' module.  We test functions by
+-- | Tests for "Data.HashMap.Lazy" and "Data.HashMap.Strict".  We test functions by
 -- comparing them to @Map@ from @containers@.
 
 #if defined(STRICT)

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -540,7 +540,7 @@ type Model k v = M.Map k v
 -- one operating on a 'Model'.
 eq :: (Eq a, Eq k, Hashable k, Ord k, Show a, Show k)
    => (Model k v -> a)       -- ^ Function that modifies a 'Model'
-   -> (HM.HashMap k v -> a)  -- ^ Function that modified a 'HashMap' in the same
+   -> (HashMap k v -> a)     -- ^ Function that modified a 'HashMap' in the same
                              -- way
    -> [(k, v)]               -- ^ Initial content of the 'HashMap' and 'Model'
    -> Property
@@ -550,7 +550,7 @@ infix 4 `eq`
 
 eq_ :: (Eq k, Eq v, Hashable k, Ord k, Show k, Show v)
     => (Model k v -> Model k v)            -- ^ Function that modifies a 'Model'
-    -> (HM.HashMap k v -> HM.HashMap k v)  -- ^ Function that modified a
+    -> (HashMap k v -> HashMap k v)        -- ^ Function that modified a
                                            -- 'HashMap' in the same way
     -> [(k, v)]                            -- ^ Initial content of the 'HashMap'
                                            -- and 'Model'
@@ -562,13 +562,13 @@ infix 4 `eq_`
 ------------------------------------------------------------------------
 -- * Helpers
 
-type HMKI = HM.HashMap Key Int
+type HMKI = HashMap Key Int
 
 sortByKey :: Ord k => [(k, v)] -> [(k, v)]
 sortByKey = List.sortBy (compare `on` fst)
 
-toAscList :: Ord k => HM.HashMap k v -> [(k, v)]
+toAscList :: Ord k => HashMap k v -> [(k, v)]
 toAscList = List.sortBy (compare `on` fst) . HM.toList
 
-toOrdMap :: Ord k => HM.HashMap k v -> M.Map k v
+toOrdMap :: Ord k => HashMap k v -> M.Map k v
 toOrdMap = M.fromList . HM.toList

--- a/tests/Properties/HashSet.hs
+++ b/tests/Properties/HashSet.hs
@@ -156,45 +156,44 @@ pToList = Set.toAscList `eq` toAscList
 
 tests :: TestTree
 tests = testGroup "Data.HashSet"
-    [
-    -- Instances
-      testGroup "instances"
-      [ testProperty "==" pEq
-      , testProperty "Permutation ==" pPermutationEq
-      , testProperty "/=" pNeq
-      , testProperty "compare reflexive" pOrd1
-      , testProperty "compare transitive" pOrd2
-      , testProperty "compare antisymmetric" pOrd3
-      , testProperty "Ord => Eq" pOrdEq
-      , testProperty "Read/Show" pReadShow
-      , testProperty "Foldable" pFoldable
-      , testProperty "Hashable" pHashable
-      ]
-    -- Basic interface
-    , testGroup "basic interface"
-      [ testProperty "size" pSize
-      , testProperty "member" pMember
-      , testProperty "insert" pInsert
-      , testProperty "delete" pDelete
-      ]
-    -- Combine
-    , testProperty "union" pUnion
-    -- Transformations
-    , testProperty "map" pMap
-    -- Folds
-    , testGroup "folds"
-      [ testProperty "foldr" pFoldr
-      , testProperty "foldl'" pFoldl'
-      ]
-    -- Filter
-    , testGroup "filter"
-      [ testProperty "filter" pFilter
-      ]
-    -- Conversions
-    , testGroup "conversions"
-      [ testProperty "toList" pToList
-      ]
+  [ -- Instances
+    testGroup "instances"
+    [ testProperty "==" pEq
+    , testProperty "Permutation ==" pPermutationEq
+    , testProperty "/=" pNeq
+    , testProperty "compare reflexive" pOrd1
+    , testProperty "compare transitive" pOrd2
+    , testProperty "compare antisymmetric" pOrd3
+    , testProperty "Ord => Eq" pOrdEq
+    , testProperty "Read/Show" pReadShow
+    , testProperty "Foldable" pFoldable
+    , testProperty "Hashable" pHashable
     ]
+  -- Basic interface
+  , testGroup "basic interface"
+    [ testProperty "size" pSize
+    , testProperty "member" pMember
+    , testProperty "insert" pInsert
+    , testProperty "delete" pDelete
+    ]
+  -- Combine
+  , testProperty "union" pUnion
+  -- Transformations
+  , testProperty "map" pMap
+  -- Folds
+  , testGroup "folds"
+    [ testProperty "foldr" pFoldr
+    , testProperty "foldl'" pFoldl'
+    ]
+  -- Filter
+  , testGroup "filter"
+    [ testProperty "filter" pFilter
+    ]
+  -- Conversions
+  , testGroup "conversions"
+    [ testProperty "toList" pToList
+    ]
+  ]
 
 ------------------------------------------------------------------------
 -- * Model

--- a/tests/Properties/HashSet.hs
+++ b/tests/Properties/HashSet.hs
@@ -35,26 +35,6 @@ instance (Eq a, Hashable a, Arbitrary a) => Arbitrary (HashSet a) where
 -- * Properties
 
 ------------------------------------------------------------------------
--- ** Instances
-
-
-
-------------------------------------------------------------------------
--- ** Basic interface
-
-pSize :: [Key] -> Property
-pSize = Set.size `eq` HS.size
-
-pMember :: Key -> [Key] -> Property
-pMember k = Set.member k `eq` HS.member k
-
-pInsert :: Key -> [Key] -> Property
-pInsert a = Set.insert a `eq_` HS.insert a
-
-pDelete :: Key -> [Key] -> Property
-pDelete a = Set.delete a `eq_` HS.delete a
-
-------------------------------------------------------------------------
 -- ** Combine
 
 pUnion :: [Key] -> [Key] -> Property
@@ -162,10 +142,14 @@ tests = testGroup "Data.HashSet"
     ]
   -- Basic interface
   , testGroup "basic interface"
-    [ testProperty "size" pSize
-    , testProperty "member" pMember
-    , testProperty "insert" pInsert
-    , testProperty "delete" pDelete
+    [ testProperty "size" $
+      \(x :: HSK) -> HS.size x === List.length (HS.toList x)
+    , testProperty "member" $
+      \e (s :: HSK) -> HS.member e s === S.member e (toOrdSet s)
+    , testProperty "insert" $
+      \e (s :: HSK) -> toOrdSet (HS.insert e s) === S.insert e (toOrdSet s)
+    , testProperty "delete" $
+      \e (s :: HSK) -> toOrdSet (HS.delete e s) === S.delete e (toOrdSet s)
     ]
   -- Combine
   , testProperty "union" pUnion

--- a/tests/Util/Key.hs
+++ b/tests/Util/Key.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveAnyClass   #-}
 {-# LANGUAGE DeriveGeneric    #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -7,7 +8,7 @@ import Data.Bits       (bit, (.&.))
 import Data.Hashable   (Hashable (hashWithSalt))
 import Data.Word       (Word16)
 import GHC.Generics    (Generic)
-import Test.QuickCheck (Arbitrary (..), Gen, Large)
+import Test.QuickCheck (Arbitrary (..), CoArbitrary (..), Function, Gen, Large)
 
 import qualified Test.QuickCheck as QC
 
@@ -17,13 +18,13 @@ data Key = K
     -- ^ The hash of the key
   , _x :: !SmallSum
     -- ^ Additional data, so we can have collisions for any hash
-  } deriving (Eq, Ord, Read, Show, Generic)
+  } deriving (Eq, Ord, Read, Show, Generic, Function, CoArbitrary)
 
 instance Hashable Key where
   hashWithSalt _ (K h _) = h
 
 data SmallSum = A | B | C | D
-  deriving (Eq, Ord, Read, Show, Generic, Enum, Bounded)
+  deriving (Eq, Ord, Read, Show, Generic, Enum, Bounded, Function, CoArbitrary)
 
 instance Arbitrary SmallSum where
   arbitrary = QC.arbitraryBoundedEnum

--- a/tests/Util/Key.hs
+++ b/tests/Util/Key.hs
@@ -43,7 +43,7 @@ instance Arbitrary Key where
 arbitraryHash :: Gen Int
 arbitraryHash = do
   let gens =
-        [ (2, (fromIntegral . QC.getLarge) <$> arbitrary @(Large Word16))
+        [ (2, fromIntegral . QC.getLarge <$> arbitrary @(Large Word16))
         , (1, QC.getSmall <$> arbitrary)
         , (1, QC.getLarge <$> arbitrary)
         ]


### PR DESCRIPTION
…by moving the test definitions directly into the trees.

Context: https://github.com/haskell-unordered-containers/unordered-containers/issues/284.

This is also preparation for the addition for more invariant-checking tests (https://github.com/haskell-unordered-containers/unordered-containers/issues/449).

---

TODO:

* [x] `HashSet` tests
* [ ] ~~More test suites?!~~ Nah