### PR TITLE
Remove outdated or confusing TODO

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -1731,9 +1731,6 @@ map :: (v1 -> v2) -> HashMap k v1 -> HashMap k v2
 map f = mapWithKey (const f)
 {-# INLINE map #-}
 
--- TODO: We should be able to use mutation to create the new
--- 'HashMap'.
-
 -- | \(O(n)\) Perform an 'Applicative' action for each key-value pair
 -- in a 'HashMap' and produce a 'HashMap' of all the results.
 --


### PR DESCRIPTION
The comment was added in 2cf94c49b4c958adeb241a5c901b629cb776dcf4.
It was possibly referring to Array.traverse which didn't use
mutable arrays at the time.