### PR TITLE
Add more invariant tests

### DIFF
--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -135,7 +135,9 @@ tests =
             bifoldr (:) (:) [] m === concatMap (\(k, v) -> [k, v]) (HM.toList m)
         , testProperty "bifoldl" $
           \(m :: HMK Key) ->
-            bifoldl (flip (:)) (flip (:)) [] m === reverse (concatMap (\(k, v) -> [k, v]) (HM.toList m))
+            bifoldl (flip (:)) (flip (:)) [] m
+            ===
+            reverse (concatMap (\(k, v) -> [k, v]) (HM.toList m))
         ]
       , testProperty "Hashable" $
         \(xs :: [(Key, Int)]) is salt ->
@@ -368,7 +370,8 @@ tests =
     -- Transformations
     , testGroup "map"
       [ testProperty "model" $
-        \(f :: Fun A B) (m :: HMK A) -> toOrdMap (HM.map (QC.applyFun f) m) === M.map (QC.applyFun f) (toOrdMap m)
+        \(f :: Fun A B) (m :: HMK A) ->
+          toOrdMap (HM.map (QC.applyFun f) m) === M.map (QC.applyFun f) (toOrdMap m)
       , testProperty "valid" $
         \(f :: Fun A B) (m :: HMK A) -> isValid (HM.map (QC.applyFun f) m)
       ]
@@ -432,7 +435,9 @@ tests =
     , testGroup "filterWithKey"
       [ testProperty "model" $
         \p (m :: HMKI) ->
-          toOrdMap (HM.filterWithKey (QC.applyFun2 p) m) === M.filterWithKey (QC.applyFun2 p) (toOrdMap m)
+          toOrdMap (HM.filterWithKey (QC.applyFun2 p) m)
+          ===
+          M.filterWithKey (QC.applyFun2 p) (toOrdMap m)
       , testProperty "valid" $
         \p (m :: HMKI) -> isValid (HM.filterWithKey (QC.applyFun2 p) m)
       ]
@@ -446,9 +451,12 @@ tests =
     , testGroup "mapMaybeWithKey"
       [ testProperty "model" $
         \(f :: Fun (Key, A) (Maybe B)) (m :: HMK A) ->
-          toOrdMap (HM.mapMaybeWithKey (QC.applyFun2 f) m) === M.mapMaybeWithKey (QC.applyFun2 f) (toOrdMap m)
+          toOrdMap (HM.mapMaybeWithKey (QC.applyFun2 f) m)
+          ===
+          M.mapMaybeWithKey (QC.applyFun2 f) (toOrdMap m)
       , testProperty "valid" $
-        \(f :: Fun (Key, A) (Maybe B)) (m :: HMK A) -> isValid (HM.mapMaybeWithKey (QC.applyFun2 f) m)
+        \(f :: Fun (Key, A) (Maybe B)) (m :: HMK A) ->
+          isValid (HM.mapMaybeWithKey (QC.applyFun2 f) m)
       ]
     -- Conversions
     , testProperty "elems" $

--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -287,28 +287,52 @@ tests =
         \k v (m :: HMKI) -> not (HM.member k m) ==> not (HM.isSubmapOf (HM.insert k v m) m)
       ]
     -- Combine
-    , testProperty "union" $
-      \(x :: HMKI) y ->
-        let z = HM.union x y
-        in  toOrdMap z === M.union (toOrdMap x) (toOrdMap y)
-    , testProperty "unionWith" $
-      \f (x :: HMKI) y ->
-        let z = HM.unionWith (QC.applyFun2 f) x y
-        in  toOrdMap z === M.unionWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
-    , testProperty "unionWithKey" $
-      \f (x :: HMKI) y ->
-        let z = HM.unionWithKey (QC.applyFun3 f) x y
-        in  toOrdMap z === M.unionWithKey (QC.applyFun3 f) (toOrdMap x) (toOrdMap y)
-    , testProperty "unions" $
-      \(ms :: [HMKI]) -> toOrdMap (HM.unions ms) === M.unions (map toOrdMap ms)
-    , testProperty "difference" $
-      \(x :: HMKI) (y :: HMKI) ->
-        toOrdMap (HM.difference x y) === M.difference (toOrdMap x) (toOrdMap y)
-    , testProperty "differenceWith" $
-      \f (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.differenceWith (QC.applyFun2 f) x y)
-        ===
-        M.differenceWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
+    , testGroup "union"
+      [ testProperty "model" $
+        \(x :: HMKI) y ->
+          let z = HM.union x y
+          in  toOrdMap z === M.union (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(x :: HMKI) y -> isValid (HM.union x y)
+      ]
+    , testGroup "unionWith"
+      [ testProperty "model" $
+        \f (x :: HMKI) y ->
+          let z = HM.unionWith (QC.applyFun2 f) x y
+          in  toOrdMap z === M.unionWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \f (x :: HMKI) y -> isValid (HM.unionWith (QC.applyFun2 f) x y)
+      ]
+    , testGroup "unionWithKey"
+      [ testProperty "model" $
+        \f (x :: HMKI) y ->
+          let z = HM.unionWithKey (QC.applyFun3 f) x y
+          in  toOrdMap z === M.unionWithKey (QC.applyFun3 f) (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \f (x :: HMKI) y -> isValid (HM.unionWithKey (QC.applyFun3 f) x y)
+      ]
+    , testGroup "unions"
+      [ testProperty "model" $
+        \(ms :: [HMKI]) -> toOrdMap (HM.unions ms) === M.unions (map toOrdMap ms)
+      , testProperty "valid" $
+        \(ms :: [HMKI]) -> isValid (HM.unions ms)
+      ]
+    , testGroup "difference"
+      [ testProperty "model" $
+        \(x :: HMKI) (y :: HMKI) ->
+          toOrdMap (HM.difference x y) === M.difference (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(x :: HMKI) (y :: HMKI) -> isValid (HM.difference x y)
+      ]
+    , testGroup "differenceWith"
+      [ testProperty "model" $
+        \f (x :: HMK A) (y :: HMK B) ->
+          toOrdMap (HM.differenceWith (QC.applyFun2 f) x y)
+          ===
+          M.differenceWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \f (x :: HMK A) (y :: HMK B) -> isValid (HM.differenceWith (QC.applyFun2 f) x y)
+      ]
     , testGroup "intersection"
       [ testProperty "model" $
         \(x :: HMKI) (y :: HMKI) ->
@@ -317,16 +341,26 @@ tests =
         \(x :: HMKI) (y :: HMKI) ->
           isValid (HM.intersection x y)
       ]
-    , testProperty "intersectionWith" $
-      \(f :: Fun (A, B) C) (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.intersectionWith (QC.applyFun2 f) x y)
-        ===
-        M.intersectionWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
-    , testProperty "intersectionWithKey" $
-      \(f :: Fun (Key, A, B) C) (x :: HMK A) (y :: HMK B) ->
-        toOrdMap (HM.intersectionWithKey (QC.applyFun3 f) x y)
-        ===
-        M.intersectionWithKey (QC.applyFun3 f) (toOrdMap x) (toOrdMap y)
+    , testGroup "intersectionWith"
+      [ testProperty "model" $
+        \(f :: Fun (A, B) C) (x :: HMK A) (y :: HMK B) ->
+          toOrdMap (HM.intersectionWith (QC.applyFun2 f) x y)
+          ===
+          M.intersectionWith (QC.applyFun2 f) (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(f :: Fun (A, B) C) (x :: HMK A) (y :: HMK B) ->
+          isValid (HM.intersectionWith (QC.applyFun2 f) x y)
+      ]
+    , testGroup "intersectionWithKey"
+      [ testProperty "model" $
+        \(f :: Fun (Key, A, B) C) (x :: HMK A) (y :: HMK B) ->
+          toOrdMap (HM.intersectionWithKey (QC.applyFun3 f) x y)
+          ===
+          M.intersectionWithKey (QC.applyFun3 f) (toOrdMap x) (toOrdMap y)
+      , testProperty "valid" $
+        \(f :: Fun (Key, A, B) C) (x :: HMK A) (y :: HMK B) ->
+          isValid (HM.intersectionWithKey (QC.applyFun3 f) x y)
+      ]
     -- Transformations
     , testProperty "map" $
       \(f :: Fun A B) (m :: HMK A) -> toOrdMap (HM.map (QC.applyFun f) m) === M.map (QC.applyFun f) (toOrdMap m)

--- a/tests/Properties/HashSet.hs
+++ b/tests/Properties/HashSet.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-} -- because of the Arbitrary instances
+
+{-# OPTIONS_GHC -fno-warn-orphans            #-} -- because of the Arbitrary instances
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-} -- https://github.com/nick8325/quickcheck/issues/344
 
 -- | Tests for the 'Data.HashSet' module.  We test functions by
 -- comparing them to @Set@ from @containers@. @Set@ is referred to as a
@@ -12,7 +15,7 @@ import Data.HashMap.Lazy     (HashMap)
 import Data.HashSet          (HashSet)
 import Data.Ord              (comparing)
 import Data.Set              (Set)
-import Test.QuickCheck       (Fun, (===), (==>))
+import Test.QuickCheck       (Fun, pattern Fn, (===), (==>))
 import Test.Tasty            (TestTree, testGroup)
 import Test.Tasty.QuickCheck (Arbitrary (..), testProperty)
 import Util.Key              (Key, keyToInt)
@@ -117,7 +120,7 @@ tests = testGroup "Data.HashSet"
     \(x :: HSK) y -> toOrdSet (HS.union x y) === S.union (toOrdSet x) (toOrdSet y)
   -- Transformations
   , testProperty "map" $
-    \(f :: Fun Key Key) (s :: HSK) -> toOrdSet (HS.map (QC.applyFun f) s) === S.map (QC.applyFun f) (toOrdSet s)
+    \(Fn f :: Fun Key Key) (s :: HSK) -> toOrdSet (HS.map f s) === S.map f (toOrdSet s)
   -- Folds
   , testProperty "foldr" $
     \(s :: HSK) ->
@@ -128,7 +131,7 @@ tests = testGroup "Data.HashSet"
       in  HS.foldl' f z0 s === S.foldl' f z0 (toOrdSet s)
   -- Filter
   , testProperty "filter" $
-    \p (s :: HSK) -> toOrdSet (HS.filter (QC.applyFun p) s) === S.filter (QC.applyFun p) (toOrdSet s)
+    \(Fn p) (s :: HSK) -> toOrdSet (HS.filter p s) === S.filter p (toOrdSet s)
   -- Conversions
   , testProperty "toList" $
     \(xs :: [Key]) -> List.sort (HS.toList (HS.fromList xs)) === S.toAscList (S.fromList xs)

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -110,7 +110,7 @@ test-suite unordered-containers-tests
       nothunks >= 0.1.3
 
   default-language: Haskell2010
-  ghc-options: -Wall
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   cpp-options: -DASSERTS
 
 benchmark benchmarks


### PR DESCRIPTION
Addresses https://github.com/haskell-unordered-containers/unordered-containers/issues/449.

Also:

* Run tests in parallel
* Use `Fn{,2,3}` pattern synonyms for improved aesthetics