### PR TITLE
Remove some dead code from insertKeyExists

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -882,9 +882,7 @@ insertKeyExists !collPos0 !h0 !k0 x0 !m0 = go collPos0 h0 k0 x0 0 m0
     go !_collPos !h !k x !_s (Leaf _hy _kx)
         = Leaf h (L k x)
     go collPos h k x s (BitmapIndexed b ary)
-        | b .&. m == 0 =
-            let !ary' = A.insert ary i $ Leaf h (L k x)
-            in bitmapIndexedOrFull (b .|. m) ary'
+        | b .&. m == 0 = Empty -- error "insertKeyExists: key not found"
         | otherwise =
             let !st  = A.index ary i
                 !st' = go collPos h k x (nextShift s) st

--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -881,12 +881,10 @@ insertKeyExists !collPos0 !h0 !k0 x0 !m0 = go collPos0 h0 k0 x0 0 m0
   where
     go !_collPos !h !k x !_s (Leaf _hy _kx)
         = Leaf h (L k x)
-    go collPos h k x s (BitmapIndexed b ary)
-        | b .&. m == 0 = Empty -- error "insertKeyExists: key not found"
-        | otherwise =
-            let !st  = A.index ary i
-                !st' = go collPos h k x (nextShift s) st
-            in BitmapIndexed b (A.update ary i st')
+    go collPos h k x s (BitmapIndexed b ary) =
+        let !st  = A.index ary i
+            !st' = go collPos h k x (nextShift s) st
+        in BitmapIndexed b (A.update ary i st')
       where m = mask h s
             i = sparseIndex b m
     go collPos h k x s (Full ary) =


### PR DESCRIPTION
The code was handling the case where a BitmapIndexed node does not
have a sub-node that could contain the known-to-exist key.