### PR TITLE
fix typos

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -652,7 +652,7 @@ lookup' h k m = case lookupRecordCollision# h k m of
   (# | (# a, _i #) #) -> Just a
 {-# INLINE lookup' #-}
 
--- The result of a lookup, keeping track of if a hash collision occured.
+-- The result of a lookup, keeping track of if a hash collision occurred.
 -- If a collision did not occur then it will have the Int value (-1).
 data LookupRes a = Absent | Present a !Int
 
@@ -2258,7 +2258,7 @@ fromList = List.foldl' (\ m (k, v) -> unsafeInsert k v m) empty
 -- > = fromList [('a', [3, 1]), ('b', [2])]
 --
 -- Note that the lists in the resulting map contain elements in reverse order
--- from their occurences in the original list.
+-- from their occurrences in the original list.
 --
 -- More generally, duplicate entries are accumulated as follows;
 -- this matters when @f@ is not commutative or not associative.

--- a/Data/HashMap/Internal/Array.hs
+++ b/Data/HashMap/Internal/Array.hs
@@ -351,7 +351,7 @@ updateM ary idx b =
   where !count = length ary
 {-# INLINE updateM #-}
 
--- | \(O(n)\) Update the element at the given positio in this array, by
+-- | \(O(n)\) Update the element at the given position in this array, by
 -- applying a function to it.  Evaluates the element to WHNF before
 -- inserting it into the array.
 updateWith' :: Array e -> Int -> (e -> e) -> Array e

--- a/Data/HashMap/Internal/List.hs
+++ b/Data/HashMap/Internal/List.hs
@@ -32,7 +32,7 @@ import Data.Maybe (fromMaybe)
 import Data.Semigroup ((<>))
 #endif
 
--- Note: previous implemenation isPermutation = null (as // bs)
+-- Note: previous implementation isPermutation = null (as // bs)
 -- was O(n^2) too.
 --
 -- This assumes lists are of equal length

--- a/Data/HashMap/Internal/Strict.hs
+++ b/Data/HashMap/Internal/Strict.hs
@@ -668,7 +668,7 @@ fromList = List.foldl' (\ m (k, !v) -> HM.unsafeInsert k v m) HM.empty
 -- > = fromList [('a', [3, 1]), ('b', [2])]
 --
 -- Note that the lists in the resulting map contain elements in reverse order
--- from their occurences in the original list.
+-- from their occurrences in the original list.
 --
 -- More generally, duplicate entries are accumulated as follows;
 -- this matters when @f@ is not commutative or not associative.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -17,7 +17,7 @@ would be no reason for it to exist, given that its functionality is a strict
 subset of ordered containers. This might seem obvious, but the author has
 rejected several proposals in the past (e.g. to switch to higher quality but
 slower hash functions) that would have made unordered-containers too slow to
-motivate its existance.
+motivate its existence.
 
 ## A note on hash functions
 
@@ -87,7 +87,7 @@ data HashMap k v
     | Collision !Hash !(A.Array (Leaf k v))
 ```
 
-Here's a quick overview in order of simplicty:
+Here's a quick overview in order of simplicity:
 
  * `Empty` -- The empty map.
  * `Leaf` -- A key-value pair.

--- a/tests/Strictness.hs
+++ b/tests/Strictness.hs
@@ -98,7 +98,7 @@ pFromListWithKeyStrict f =
 -- argument, just the first argument, just the second argument,
 -- or both arguments are bottom. It would be quite tempting to
 -- just use Maybe A -> Maybe A -> Maybe A, but that would not
--- necessarily be continous.
+-- necessarily be continuous.
 pFromListWithValueResultStrict :: [(Key, Maybe A)]
                                -> Fun (Maybe A, Maybe A) A
                                -> Fun (Maybe A, Maybe A) Bool


### PR DESCRIPTION
Data/HashMap/Internal.hs
Data/HashMap/Internal/Array.hs
Data/HashMap/Internal/List.hs
Data/HashMap/Internal/Strict.hs
docs/developer-guide.md
tests/Strictness.hs

unattended to

```sh
$ grep -nr documentaton unordered-containers
unordered-containers/CHANGES.md:193: * Add internal documentaton. (Thanks, Johan Tibell)
$
```

a recursive `grep` for Homogenous and Homogeonous might also be run on the repo
