### PR TITLE
Future-proof against potential Prelude.foldl'

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -164,8 +164,8 @@ import Data.HashMap.Internal.List (isPermutationBy, unorderedCompare)
 import Data.Semigroup             (Semigroup (..), stimesIdempotentMonoid)
 import GHC.Exts                   (Int (..), Int#, TYPE, (==#))
 import GHC.Stack                  (HasCallStack)
-import Prelude                    hiding (filter, foldl, foldr, lookup, map,
-                                   null, pred)
+import Prelude                    hiding (Foldable(..), filter, lookup, map,
+                                   pred)
 import Text.Read                  hiding (step)
 
 import qualified Data.Data                   as Data

--- a/Data/HashMap/Internal/Array.hs
+++ b/Data/HashMap/Internal/Array.hs
@@ -94,7 +94,7 @@ import GHC.Exts            (Int (..), SmallArray#, SmallMutableArray#,
                             unsafeFreezeSmallArray#, unsafeThawSmallArray#,
                             writeSmallArray#)
 import GHC.ST              (ST (..))
-import Prelude             hiding (all, filter, foldMap, foldl, foldr, length,
+import Prelude             hiding (Foldable(..), all, filter,
                             map, read, traverse)
 
 import qualified GHC.Exts                   as Exts

--- a/Data/HashSet/Internal.hs
+++ b/Data/HashSet/Internal.hs
@@ -98,7 +98,7 @@ import Data.Hashable.Lifted  (Hashable1 (..), Hashable2 (..))
 import Data.HashMap.Internal (HashMap, equalKeys, equalKeys1, foldMapWithKey,
                               foldlWithKey, foldrWithKey)
 import Data.Semigroup        (Semigroup (..), stimesIdempotentMonoid)
-import Prelude               hiding (filter, foldl, foldr, map, null)
+import Prelude               hiding (Foldable(..), filter, map)
 import Text.Read
 
 import qualified Data.Data                  as Data


### PR DESCRIPTION
See https://github.com/haskell/core-libraries-committee/issues/167

This is, of course, a bit speculative at the moment, but given that the change does not involve CPP, it should not hurt to merge it early to simplify further impact assessment.