### PR TITLE
Make debug flag manual

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -41,6 +41,7 @@ tested-with:
 flag debug
   description:  Enable debug support
   default:      False
+  manual:       True
 
 library
   exposed-modules:


### PR DESCRIPTION
By default flags are automatic. The `debug` flag is intended to be enabled manually, it seems bizarre to allow solvers to flip it.