### PR TITLE
Update moduledoc of `HashMap.Strict` to mention correct branching factor of 32

### DIFF
--- a/Data/HashMap/Strict.hs
+++ b/Data/HashMap/Strict.hs
@@ -19,7 +19,7 @@
 -- strings.
 --
 -- Many operations have a average-case complexity of \(O(\log n)\).  The
--- implementation uses a large base (i.e. 16) so in practice these
+-- implementation uses a large base (i.e. 32) so in practice these
 -- operations are constant time.
 module Data.HashMap.Strict
     (


### PR DESCRIPTION
Fixes https://github.com/haskell-unordered-containers/unordered-containers/issues/493