### PR TITLE
Remove up version limit of template-haskell and hashable

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -29,7 +29,8 @@ cabal-version:  >=1.10
 extra-source-files: CHANGES.md
 
 tested-with:
-  GHC ==9.8.1
+  GHC ==9.10.1
+   || ==9.8.1
    || ==9.6.3
    || ==9.4.7
    || ==9.2.8
@@ -59,8 +60,8 @@ library
   build-depends:
     base >= 4.10 && < 5,
     deepseq >= 1.4.3,
-    hashable >= 1.2.5 && < 1.5,
-    template-haskell < 2.22
+    hashable >= 1.2.5,
+    template-haskell
 
   default-language: Haskell2010
 


### PR DESCRIPTION
Limiting upper version of packages causes dependency hell. The only reason why `master` does not compile with `hashable 1.5.0.0` and `template-haskell 2.22.0.0`, that I use in my project, is upper limits for its versions. It would be better to limit upper version of libraries only when they change API in incompatible way.

If API of any dependency will change in incompatible way, `unordered-containers` will not compile anyway. If next versions of dependencies would not break API (that is most often scenario), `unordered-containers` will have compatibility for free, without updating upstream from `<22` to `<23` etc with every new dependency release.