### PR TITLE
Support ghc 9.12

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -59,8 +59,8 @@ library
   build-depends:
     base >= 4.10 && < 5,
     deepseq >= 1.4.3,
-    hashable >= 1.2.5 && < 1.5,
-    template-haskell < 2.22
+    hashable >= 1.2.5 && < 1.6,
+    template-haskell < 2.24
 
   default-language: Haskell2010
 


### PR DESCRIPTION
Also bump upper bound on hashable dependency.

Currently needs the following in a `cabal.project` file:
```
allow-newer:
  , hashable:base
  , splitmix:base
  , tagged:template-haskell
  , vector-stream:ghc-prim
```