### PR TITLE
Fixes docs of Data.HashMap.Lazy.fromList: it takes O(n * log(n))

### DIFF
--- a/Data/HashMap/Internal.hs
+++ b/Data/HashMap/Internal.hs
@@ -2229,7 +2229,7 @@ toList :: HashMap k v -> [(k, v)]
 toList t = Exts.build (\ c z -> foldrWithKey (curry c) z t)
 {-# INLINE toList #-}
 
--- | \(O(n)\) Construct a map with the supplied mappings.  If the list
+-- | \(O(n \log n)\) Construct a map with the supplied mappings.  If the list
 -- contains duplicate mappings, the later mappings take precedence.
 fromList :: (Eq k, Hashable k) => [(k, v)] -> HashMap k v
 fromList = List.foldl' (\ m (k, v) -> unsafeInsert k v m) empty


### PR DESCRIPTION
Fixes the incorrect documentation in `Data.HashMap.Lazy.fromList` / `Data.HashMap.Internal.fromList`: This takes linearithmic time rather than linear time, since we do `n` insertions, each of which takes (assuming no collisions!) `log32(n)`  steps as per the documentation of `insert`.

Fixes #309