### PR TITLE
Remove bad isSubmapOf testcase

### DIFF
--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -258,8 +258,6 @@ tests =
         \(x :: HMKI) -> HM.isSubmapOf x x
       , testProperty "m1 ⊆ m1 ∪ m2" $
         \(x :: HMKI) y -> HM.isSubmapOf x (HM.union x y)
-      , testProperty "m1 ⊈ m2  ⇒  m1 ∪ m2 ⊈ m1" $
-        \(m1 :: HMKI) m2 -> not (HM.isSubmapOf m1 m2) ==> HM.isSubmapOf m1 (HM.union m1 m2)
       , testProperty "m1\\m2 ⊆ m1" $
         \(m1 :: HMKI) (m2 :: HMKI) -> HM.isSubmapOf (HM.difference m1 m2) m1
       , testProperty "m1 ∩ m2 ≠ ∅  ⇒  m1 ⊈ m1\\m2 " $


### PR DESCRIPTION
I just stumbled upon this while working on #491:


The property tested is covered by the test case above, but the property claimed in the test name is plain wrong:

```
   m1 ⊈ m2  ⇒  m1 ∪ m2 ⊈ m1:          FAIL
     *** Failed! Falsified (after 1 test and 2 shrinks):
     fromList [(K {hash = 0, _x = A},0)]
     fromList []
```