### PR TITLE
Adjust GHC options as recommended by tasty-bench

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -133,7 +133,9 @@ benchmark benchmarks
     unordered-containers
 
   default-language: Haskell2010
-  ghc-options: -Wall -O2 -rtsopts "-with-rtsopts=-A32m --nonmoving-gc"
+  ghc-options: -Wall -O2 -rtsopts "-with-rtsopts=-A32m"
+  if impl(ghc >= 8.6)
+    ghc-options: -fproc-alignment=64
   -- cpp-options: -DBENCH_containers_Map -DBENCH_containers_IntMap -DBENCH_hashmap_Map
 
 source-repository head

--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -133,9 +133,7 @@ benchmark benchmarks
     unordered-containers
 
   default-language: Haskell2010
-  ghc-options: -Wall -O2 -rtsopts "-with-rtsopts=-A32m"
-  if impl(ghc >= 8.6)
-    ghc-options: -fproc-alignment=64
+  ghc-options: -Wall -O2 -rtsopts "-with-rtsopts=-A32m" -fproc-alignment=64
   -- cpp-options: -DBENCH_containers_Map -DBENCH_containers_IntMap -DBENCH_hashmap_Map
 
 source-repository head


### PR DESCRIPTION
* `--nonmoving-gc` is no longer recommended
* `-fproc-alignment=64` is recommended especially for comparisons between code versions