### PR TITLE
Remove redundant tests for isSubmapOf

### DIFF
--- a/tests/Properties/HashMapLazy.hs
+++ b/tests/Properties/HashMapLazy.hs
@@ -256,19 +256,8 @@ tests =
         \(x :: HMKI) y -> HM.isSubmapOf x y === M.isSubmapOf (toOrdMap x) (toOrdMap y)
       , testProperty "m ⊆ m" $
         \(x :: HMKI) -> HM.isSubmapOf x x
-      , testProperty "m1 ⊆ m1 ∪ m2" $
-        \(x :: HMKI) y -> HM.isSubmapOf x (HM.union x y)
-      , testProperty "m1\\m2 ⊆ m1" $
-        \(m1 :: HMKI) (m2 :: HMKI) -> HM.isSubmapOf (HM.difference m1 m2) m1
-      , testProperty "m1 ∩ m2 ≠ ∅  ⇒  m1 ⊈ m1\\m2 " $
-        \(m1 :: HMKI) (m2 :: HMKI) ->
-          not (HM.null (HM.intersection m1 m2)) ==>
-          not (HM.isSubmapOf m1 (HM.difference m1 m2))
       , testProperty "delete k m ⊆ m" $
-        \(m :: HMKI) ->
-          not (HM.null m) ==>
-          QC.forAll (QC.elements (HM.keys m)) $ \k ->
-          HM.isSubmapOf (HM.delete k m) m
+        \k (m :: HMKI) -> HM.isSubmapOf (HM.delete k m) m
       , testProperty "m ⊈ delete k m " $
         \(m :: HMKI) ->
           not (HM.null m) ==>


### PR DESCRIPTION
As pointed out by @treeowl in https://github.com/haskell-unordered-containers/unordered-containers/pull/517#discussion_r2404597676.