### PR TITLE
Remove the `Array.index` function

### DIFF
--- a/Data/HashMap/Internal/Array.hs
+++ b/Data/HashMap/Internal/Array.hs
@@ -42,7 +42,6 @@ module Data.HashMap.Internal.Array
     , lengthM
     , read
     , write
-    , index
     , indexM
     , index#
     , update
@@ -267,12 +266,11 @@ write ary _i@(I# i#) b = ST $ \ s ->
             s' -> (# s' , () #)
 {-# INLINE write #-}
 
-index :: Array a -> Int -> a
-index ary _i@(I# i#) =
-    CHECK_BOUNDS("index", length ary, _i)
-        case indexSmallArray# (unArray ary) i# of (# b #) -> b
-{-# INLINE index #-}
-
+-- | Note that we don't have an 'index' function with type
+--
+-- > Array a -> Int -> a
+--
+-- We used to have it, but it was prone to creating thunks. See #538.
 index# :: Array a -> Int -> (# a #)
 index# ary _i@(I# i#) =
     CHECK_BOUNDS("index#", length ary, _i)

--- a/Data/HashMap/Internal/Debug.hs
+++ b/Data/HashMap/Internal/Debug.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP              #-}
+{-# LANGUAGE MagicHash        #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UnboxedTuples    #-}
 
 -- | = WARNING
 --
@@ -125,12 +127,14 @@ valid t     = validInternal initialSubHashPath t
 
     validSubTrees p b ary
       | A.length ary == 1
-      , isLeafOrCollision (A.index ary 0)
+      , (# st #) <- A.index# ary 0
+      , isLeafOrCollision st
       = Invalid INV5_BitmapIndexed_invalid_single_subtree p
       | otherwise = go b
       where
         go 0  = Valid
-        go b' = validInternal (addSubHash p (fromIntegral c)) (A.index ary i) <> go b''
+        go b' = case A.index# ary i of
+          (# st #) -> validInternal (addSubHash p (fromIntegral c)) st <> go b''
           where
             c = countTrailingZeros b'
             m = 1 `unsafeShiftL` c


### PR DESCRIPTION
...due to its tendency to create thunks.

In a few cases it was possible to avoid forcing the returned
array element, e.g. in `insertNewKey` and `deleteKeyExists`.

Fixes #538.