### PR TITLE
readme: Add section with performance tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,44 @@ performance critical use, both in terms of large data quantities and high speed.
 The declared cost of each operation is either worst-case or amortized, but
 remains valid even if structures are shared.
 
+### How to get the best performance out of this package
+
+#### Enable hardware support for `popCount`
+
+This package makes heavy use of the `popCount` function. To allow GHC to use the
+`popcnt` instruction available on modern x86 and x86-64 platforms, enable GHC's
+`-msse4.2` option. Since code from `unordered-containers` may spread to other
+packages due to inlining and specialization, it's best to use this setting for
+all packages in your project:
+
+In your `cabal.project`:
+
+```
+package *
+  ghc-options: -msse4.2
+```
+
+In your `stack.yaml`:
+
+```
+ghc-options:
+  "$everything": -msse4.2
+```
+
+#### Make sure that your keys have a good hash distribution
+
+TODO (few collisions, good HAMT shape)
+
+#### Make sure that your keys' `hash` method is fast
+
+TODO
+
+#### Make sure that your keys' `(==)` method is fast
+
+TODO (pointer equality!)
+
+### More documentation
+
 For background information and design considerations on this package see the
 [Developer Guide](docs/developer-guide.md).
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ immediately without inspecting the contents. The `Eq` instances of `Text` and
 `ByteString` already short-circuit on length, and `Hashed` compares cached
 hashes before comparing the underlying values.
 
+#### Re-use the old value instead of inserting an equal one
+
+Update functions such as `insertWith`, `adjust`, `update`, `alter` and `alterF`
+check whether the value you produce is *pointer-equal* to the one already
+stored. When it is, the original map is returned unchanged, with no new `Leaf`
+and no copying of the nodes along the path from the root to the key.
+
+You can take advantage of this by returning the existing value itself when an
+update turns out to be a no-op, rather than constructing a fresh but equal value:
+
+```haskell
+-- `f` returns its argument unchanged when there is nothing to do, so
+-- unordered-containers re-uses the existing value and the whole map:
+adjust (\v -> if shouldUpdate v then update v else v) k m
+```
+
 ### More documentation
 
 For background information and design considerations on this package see the

--- a/README.md
+++ b/README.md
@@ -32,15 +32,44 @@ ghc-options:
 
 #### Make sure that your keys have a good hash distribution
 
-TODO (few collisions, good HAMT shape)
+`HashMap` and `HashSet` store their contents in a tree that branches on
+successive groups of bits taken from the keys' hash values. They perform best
+when those hashes are well distributed:
+
+* Keys with *identical* hashes cannot be separated by the tree at all. They end
+  up together in a collision node, where lookups and updates degrade to a linear
+  scan. A hash function that produces frequent collisions can therefore turn
+  near-`O(1)` operations into `O(n)` ones.
+* Keys whose hashes merely *share many bits* produce deeper, more sparsely
+  populated trees, which means more indirections per operation and higher memory
+  use.
+
+Note that all bits of the hash matter, since different levels of the tree use
+different ranges of bits.
 
 #### Make sure that your keys' `hash` method is fast
 
-TODO
+`hash` is evaluated for essentially every `lookup`, `insert`, `delete`, etc., so
+it sits squarely on the hot path. For composite keys (records, tuples, nested
+structures) hashing can easily dominate the cost of an operation.
+
+If you repeatedly use the same expensive-to-hash keys, consider wrapping them in
+[`Data.Hashable.Hashed`](https://hackage.haskell.org/package/hashable/docs/Data-Hashable.html#t:Hashed),
+which caches the hash so that it is computed only once per key.
 
 #### Make sure that your keys' `(==)` method is fast
 
-TODO (pointer equality!)
+Once the tree has narrowed the candidates down using hash bits, `(==)` is used
+to confirm that a stored key really matches the query key (and to pick the right
+entry within a collision node). For large or deeply nested keys this comparison
+can be costly.
+
+A useful trick for keys that are often physically shared (for example interned
+strings, or values drawn from a shared pool) is to start `(==)` with a
+pointer-equality check, so that the common "same object" case returns `True`
+immediately without inspecting the contents. The `Eq` instances of `Text` and
+`ByteString` already short-circuit on length, and `Hashed` compares cached
+hashes before comparing the underlying values.
 
 ### More documentation
 


### PR DESCRIPTION
Context: https://github.com/haskell-unordered-containers/unordered-containers/issues/462

TODO:

* [ ] Use `-O2` instead of `-O1`?! Or possibly specific flags?! (The `differenceWith` bench are significantly slower with `-O1` instead of `-O2`, but `-fspec-constr` seems to recuperate most of loss.)
* [ ] Help u-c reduce allocations by re-using the old value instead of inserting an equal one.
* [ ] Avoid `String` keys?!
* [ ] Specialization
* [ ] Prefer keys that can be unboxed to an unlifted representation.