### PR TITLE
Reword disclaimer regarding hash collision attacks

### DIFF
--- a/unordered-containers.cabal
+++ b/unordered-containers.cabal
@@ -13,7 +13,7 @@ description:
   .
   This package currently provides no defenses against hash collision attacks
   such as HashDoS.
-  Users who need to store input from untrusted sources are advised to use
+  Users who need to store keys derived from untrusted input are advised to use
   @Data.Map@ or @Data.Set@ from the @containers@ package instead.
 license:        BSD3
 license-file:   LICENSE


### PR DESCRIPTION
The old wording could be misunderstood to mean that even HashMap _values_ from untrusted sources could be problematic. The new wording stresses that the _keys_ are the problem.