### PR TITLE
Add cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,4 @@
+packages: ./*.cabal
+
+package unordered-containers
+  ghc-options: -msse4.2


### PR DESCRIPTION
`-msse4.2` shouldn't cause any problems on any reasonably modern systems.