### PR TITLE
32bit-ci: pin GHC to 9.6.7

### DIFF
--- a/.github/workflows/32bit-ci.yml
+++ b/.github/workflows/32bit-ci.yml
@@ -22,7 +22,9 @@ jobs:
       run: |
         apt-get update -y
         apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl libncurses5 libtinfo5 libncurses5-dev libtinfo-dev
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh
+        # Pin the GHC version: the i386/ubuntu:bionic container can't run the
+        # deb10 i386 bindist that ghcup's "recommended" GHC moved to (see #596).
+        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 BOOTSTRAP_HASKELL_GHC_VERSION=9.6.7 sh
     - uses: actions/checkout@v1 #This version must stay old enough to remain compatible with the container image
     - name: Test
       run: |


### PR DESCRIPTION
The `i386` job in `32bit-ci` installs ghcup's **recommended** GHC, which is unpinned. The recommended version moved from 9.6.7 to 9.10.3, and the new **deb10** i386 bindist's `make install` fails on our `i386/ubuntu:bionic` container, breaking CI on every PR.

| Run | Recommended GHC | i386 bindist | `make install` |
|-----|-----------------|--------------|----------------|
| last green master (2026-06-11) | 9.6.7 | `ghc-9.6.7-i386-deb9-linux` | ✅ |
| current | 9.10.3 | `ghc-9.10.3-i386-deb10-linux` | ❌ exit 2 |

This pins GHC to **9.6.7** (the deb9 bindist, last known to install on this container) via `BOOTSTRAP_HASKELL_GHC_VERSION`, so a metadata bump can't break CI unannounced.

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)